### PR TITLE
chore: bump app version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rayon-db",
  "rayon-platform",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "rayon-db"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rayon-types",
  "tantivy",
@@ -3208,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "rayon-core 0.1.0",
+ "rayon-core 0.2.0",
  "rayon-db",
  "rayon-features",
  "rayon-platform",
@@ -3225,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-features"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "rayon-core 0.1.0",
+ "rayon-core 0.2.0",
  "rayon-types",
  "serde",
  "serde_json",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "rayon-platform"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "plist",
  "rayon-types",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "rayon-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rayon/desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "rayon",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.github.alexandrelam",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- bump the Rust workspace package version from 0.1.0 to 0.2.0
- bump the desktop package version from 0.1.0 to 0.2.0
- bump the Tauri app version and align local Cargo.lock workspace package entries

## Verification
- pre-commit hooks passed
- pre-push hooks passed
- frontend tests passed
- Rust tests passed