### PR TITLE
Show app version in launcher header

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -3,6 +3,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as tauriApp from "@tauri-apps/api/app";
 
 import App from "./App";
 import type {
@@ -11,6 +12,10 @@ import type {
   SearchResult,
 } from "./commandExecution";
 import * as launcherApi from "./features/launcher/api";
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn(),
+}));
 
 vi.mock("./features/launcher/api", () => ({
   executeLauncherCommand: vi.fn(),
@@ -106,6 +111,7 @@ describe("App", () => {
     vi.mocked(launcherApi.searchInteractiveSession).mockResolvedValue(
       interactiveSession({ results: [] }),
     );
+    vi.mocked(tauriApp.getVersion).mockResolvedValue("0.2.0");
     vi.mocked(launcherApi.executeLauncherCommand).mockResolvedValue({
       kind: "completed",
       output: "done",
@@ -121,10 +127,23 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("Command Palette")).toBeTruthy();
+    expect(await screen.findByText("v0.2.0")).toBeTruthy();
     expect(screen.getByLabelText("Command search").getAttribute("placeholder")).toBe(
       "Type a command",
     );
     expect(screen.queryByLabelText("Search results")).toBeNull();
+  });
+
+  it("renders without the version label when loading the app version fails", async () => {
+    vi.mocked(tauriApp.getVersion).mockRejectedValue(new Error("failed to read app version"));
+
+    render(<App />);
+
+    expect(await screen.findByText("Command Palette")).toBeTruthy();
+    await waitFor(() => {
+      expect(tauriApp.getVersion).toHaveBeenCalled();
+    });
+    expect(screen.queryByText("v0.2.0")).toBeNull();
   });
 
   it("navigates search results with the keyboard and executes the selected command", async () => {

--- a/apps/desktop/src/features/launcher/components/LauncherHeader.tsx
+++ b/apps/desktop/src/features/launcher/components/LauncherHeader.tsx
@@ -1,15 +1,23 @@
 import type { LauncherHeaderViewModel } from "@/features/launcher/types";
 
-export function LauncherHeader({ title, subtitle }: LauncherHeaderViewModel) {
+export function LauncherHeader({ title, subtitle, version }: LauncherHeaderViewModel) {
   return (
-    <header className="grid min-w-0 gap-0.5">
-      <p className="m-0 text-[0.73rem] font-semibold tracking-[0.16em] text-[var(--eyebrow)] uppercase">
-        rayon
-      </p>
-      <h1 className="m-0 text-[1.12rem] font-[640] tracking-[-0.02em]">{title}</h1>
-      {subtitle ? (
-        <p className="m-0 min-w-0 text-[0.82rem] text-[var(--result-id)] [overflow-wrap:anywhere]">
-          {subtitle}
+    <header className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-0.5">
+      <div className="min-w-0">
+        <p className="m-0 text-[0.73rem] font-semibold tracking-[0.16em] text-[var(--eyebrow)] uppercase">
+          rayon
+        </p>
+        <h1 className="m-0 text-[1.12rem] font-[640] tracking-[-0.02em]">{title}</h1>
+        {subtitle ? (
+          <p className="m-0 min-w-0 text-[0.82rem] text-[var(--result-id)] [overflow-wrap:anywhere]">
+            {subtitle}
+          </p>
+        ) : null}
+      </div>
+
+      {version ? (
+        <p className="m-0 self-start justify-self-end pt-0.5 text-[0.72rem] font-medium tracking-[0.08em] text-[var(--result-id)]">
+          v{version}
         </p>
       ) : null}
     </header>

--- a/apps/desktop/src/features/launcher/types.ts
+++ b/apps/desktop/src/features/launcher/types.ts
@@ -13,6 +13,7 @@ export type LauncherResultItemViewModel = {
 export type LauncherHeaderViewModel = {
   title: string;
   subtitle: string | null;
+  version: string | null;
 };
 
 export type LauncherFooterViewModel = {

--- a/apps/desktop/src/features/launcher/useLauncherController.ts
+++ b/apps/desktop/src/features/launcher/useLauncherController.ts
@@ -1,4 +1,5 @@
 import { type KeyboardEventHandler, useEffect, useRef, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
 
 import {
   beginPendingExecution,
@@ -55,6 +56,7 @@ export function useLauncherController(): LauncherController {
   const [executionResult, setExecutionResult] = useState("");
   const [error, setError] = useState("");
   const [pendingExecution, setPendingExecution] = useState<PendingExecution | null>(null);
+  const [appVersion, setAppVersion] = useState<string | null>(null);
   const interactiveSessionId = interactiveSession?.session_id ?? null;
   const activeResults = interactiveSession ? interactiveSession.results : results;
   const selectedResultId = activeResults[selectedIndex]?.id ?? null;
@@ -80,6 +82,29 @@ export function useLauncherController(): LauncherController {
     inputRef.current?.focus();
     applyThemePreference("system");
     void refreshThemePreference();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAppVersion() {
+      try {
+        const version = await getVersion();
+        if (!cancelled) {
+          setAppVersion(version);
+        }
+      } catch {
+        if (!cancelled) {
+          setAppVersion(null);
+        }
+      }
+    }
+
+    void loadAppVersion();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -539,6 +564,7 @@ export function useLauncherController(): LauncherController {
       pendingExecution && activeArgument
         ? `${activeArgument.label}${activeArgument.required ? " · required" : " · optional"}`
         : (interactiveSession?.subtitle ?? null),
+    version: appVersion,
   };
 
   const argumentPanel: LauncherArgumentPanelViewModel | null =


### PR DESCRIPTION
## Summary\n- show the running Rayon app version in the launcher header\n- source the version from the Tauri runtime and hide it if lookup fails\n- add frontend coverage for successful and failed version loading\n\nCloses #4