### PR TITLE
Add Chrome tab search to the launcher

### DIFF
--- a/apps/desktop/src-tauri/src/app/launcher.rs
+++ b/apps/desktop/src-tauri/src/app/launcher.rs
@@ -92,7 +92,8 @@ mod tests {
     use super::*;
     use rayon_db::SearchIndexStats;
     use rayon_types::{
-        CommandId, InstalledApp, ProcessMatch, SearchableItemDocument, ThemePreference,
+        BrowserTab, BrowserTabTarget, CommandId, InstalledApp, ProcessMatch,
+        SearchableItemDocument, ThemePreference,
     };
     use std::fs;
     use std::path::Path;
@@ -116,6 +117,14 @@ mod tests {
         }
 
         fn open_url(&self, _url: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn search_browser_tabs(&self, _query: &str) -> Result<Vec<BrowserTab>, String> {
+            Ok(Vec::new())
+        }
+
+        fn focus_browser_tab(&self, _target: &BrowserTabTarget) -> Result<(), String> {
             Ok(())
         }
 

--- a/apps/desktop/src-tauri/src/app/state.rs
+++ b/apps/desktop/src-tauri/src/app/state.rs
@@ -4,18 +4,22 @@ use rayon_db::TantivySearchIndex;
 use rayon_features::ThemeSettingsStore;
 use rayon_platform::MacOsAppManager;
 use rayon_types::{
-    CommandExecutionRequest, CommandExecutionResult, CommandInvocationResult,
+    BrowserTab, CommandExecutionRequest, CommandExecutionResult, CommandInvocationResult,
     InteractiveSessionQueryRequest, InteractiveSessionState, InteractiveSessionSubmitRequest,
-    InteractiveSessionSubmitResult, SearchResult,
+    InteractiveSessionSubmitResult, SearchResult, SearchResultKind, SearchableItemDocument,
 };
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tauri::AppHandle;
+
+const BROWSER_TAB_SEARCH_LIMIT: usize = 20;
 
 pub struct AppState {
     launcher: RwLock<LauncherService>,
     platform: Arc<dyn AppPlatform>,
     search_index: Arc<dyn SearchIndex>,
     theme_settings: Arc<ThemeSettingsStore>,
+    browser_tab_search_cache: Mutex<BrowserTabSearchCache>,
 }
 
 impl AppState {
@@ -36,6 +40,7 @@ impl AppState {
             platform,
             search_index: app_index,
             theme_settings,
+            browser_tab_search_cache: Mutex::new(BrowserTabSearchCache::new()?),
         })
     }
 
@@ -52,8 +57,16 @@ impl AppState {
         self.read_launcher().search(query)
     }
 
-    pub fn search_browser_tabs(&self, query: &str) -> Vec<SearchResult> {
-        self.read_launcher().search_browser_tabs(query)
+    pub fn search_browser_tabs(&self, query: &str, refresh: bool) -> Vec<SearchResult> {
+        match self.browser_tab_search_cache.lock() {
+            Ok(mut cache) => cache.search(self.platform.as_ref(), query, refresh),
+            Err(poisoned) => {
+                eprintln!("browser tab search cache lock poisoned");
+                poisoned
+                    .into_inner()
+                    .search(self.platform.as_ref(), query, refresh)
+            }
+        }
     }
 
     pub fn execute_command(
@@ -104,6 +117,117 @@ impl AppState {
     }
 }
 
+struct BrowserTabSearchCache {
+    tabs_by_id: HashMap<String, BrowserTab>,
+    ordered_tab_ids: Vec<String>,
+    search_index: TantivySearchIndex,
+    initialized: bool,
+}
+
+impl BrowserTabSearchCache {
+    fn new() -> Result<Self, String> {
+        Ok(Self {
+            tabs_by_id: HashMap::new(),
+            ordered_tab_ids: Vec::new(),
+            search_index: TantivySearchIndex::create_in_memory()
+                .map_err(|error| error.to_string())?,
+            initialized: false,
+        })
+    }
+
+    fn search(
+        &mut self,
+        platform: &dyn AppPlatform,
+        query: &str,
+        refresh: bool,
+    ) -> Vec<SearchResult> {
+        if refresh || !self.initialized {
+            if let Err(error) = self.refresh(platform) {
+                eprintln!("browser tab refresh failed: {error}");
+                return Vec::new();
+            }
+        }
+
+        let normalized_query = query.trim();
+        if normalized_query.is_empty() {
+            return self
+                .ordered_tab_ids
+                .iter()
+                .take(BROWSER_TAB_SEARCH_LIMIT)
+                .filter_map(|tab_id| self.tabs_by_id.get(tab_id))
+                .cloned()
+                .map(browser_tab_search_result)
+                .collect();
+        }
+
+        let item_ids = match self
+            .search_index
+            .search_item_ids(normalized_query, BROWSER_TAB_SEARCH_LIMIT)
+        {
+            Ok(item_ids) => item_ids,
+            Err(error) => {
+                eprintln!("browser tab index search failed: {error}");
+                return Vec::new();
+            }
+        };
+
+        item_ids
+            .into_iter()
+            .filter_map(|item_id| self.tabs_by_id.get(&item_id))
+            .cloned()
+            .map(browser_tab_search_result)
+            .collect()
+    }
+
+    fn refresh(&mut self, platform: &dyn AppPlatform) -> Result<(), String> {
+        let tabs = platform.search_browser_tabs("")?;
+        let documents = tabs
+            .iter()
+            .map(|tab| SearchableItemDocument {
+                id: tab.command_id(),
+                kind: SearchResultKind::BrowserTab,
+                title: tab.title.clone(),
+                subtitle: Some(tab.subtitle()),
+                owner_plugin_id: None,
+                search_text: tab.search_text(),
+            })
+            .collect::<Vec<_>>();
+
+        self.search_index
+            .replace_items(&documents)
+            .map_err(|error| error.to_string())?;
+
+        self.tabs_by_id = tabs
+            .iter()
+            .cloned()
+            .map(|tab| (tab.command_id().to_string(), tab))
+            .collect();
+        self.ordered_tab_ids = tabs
+            .into_iter()
+            .map(|tab| tab.command_id().to_string())
+            .collect();
+        self.initialized = true;
+        Ok(())
+    }
+}
+
+fn browser_tab_search_result(tab: BrowserTab) -> SearchResult {
+    let subtitle = tab.subtitle();
+    SearchResult {
+        id: tab.command_id(),
+        title: tab.title,
+        subtitle: Some(subtitle),
+        icon_path: None,
+        kind: SearchResultKind::BrowserTab,
+        owner_plugin_id: None,
+        keywords: Vec::new(),
+        starts_interactive_session: false,
+        close_launcher_on_success: true,
+        input_mode: rayon_types::CommandInputMode::Structured,
+        arguments: Vec::new(),
+    }
+}
+
 pub fn write_launcher(launcher: &RwLock<LauncherService>) -> RwLockWriteGuard<'_, LauncherService> {
     match launcher.write() {
         Ok(launcher) => launcher,
@@ -111,5 +235,128 @@ pub fn write_launcher(launcher: &RwLock<LauncherService>) -> RwLockWriteGuard<'_
             eprintln!("launcher lock poisoned while writing");
             poisoned.into_inner()
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use rayon_types::{BrowserTabTarget, CommandId, InstalledApp, ProcessMatch};
+    use std::sync::Mutex;
+
+    struct StubPlatform {
+        browser_tabs: Mutex<Vec<BrowserTab>>,
+        search_calls: Mutex<usize>,
+    }
+
+    impl AppPlatform for StubPlatform {
+        fn discover_apps(&self) -> Result<Vec<InstalledApp>, String> {
+            Ok(Vec::new())
+        }
+
+        fn launch_app(&self, _app: &InstalledApp) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn open_url(&self, _url: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn search_browser_tabs(&self, _query: &str) -> Result<Vec<BrowserTab>, String> {
+            *self.search_calls.lock().unwrap() += 1;
+            Ok(self.browser_tabs.lock().unwrap().clone())
+        }
+
+        fn focus_browser_tab(&self, _target: &BrowserTabTarget) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn search_processes(&self, _query: &str) -> Result<Vec<ProcessMatch>, String> {
+            Ok(Vec::new())
+        }
+
+        fn terminate_process(&self, _pid: u32) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    fn sample_tab(title: &str, url: &str, window_index: u32, tab_index: u32) -> BrowserTab {
+        BrowserTab {
+            browser: "chrome".into(),
+            window_id: format!("window-{window_index}"),
+            window_index,
+            active_tab_index: tab_index,
+            tab_index,
+            title: title.into(),
+            url: url.into(),
+        }
+    }
+
+    #[test]
+    fn browser_tab_search_cache_refreshes_only_on_request() {
+        let platform = StubPlatform {
+            browser_tabs: Mutex::new(vec![sample_tab(
+                "Issue 15",
+                "https://github.com/alexandrelam/rayon/issues/15",
+                1,
+                1,
+            )]),
+            search_calls: Mutex::new(0),
+        };
+        let mut cache = BrowserTabSearchCache::new().unwrap();
+
+        let first_results = cache.search(&platform, "issue", true);
+        let second_results = cache.search(&platform, "rayon", false);
+
+        assert_eq!(first_results.len(), 1);
+        assert_eq!(second_results.len(), 1);
+        assert_eq!(*platform.search_calls.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn browser_tab_search_cache_replaces_stale_tabs_on_refresh() {
+        let platform = StubPlatform {
+            browser_tabs: Mutex::new(vec![sample_tab("Old Tab", "https://old.example", 1, 1)]),
+            search_calls: Mutex::new(0),
+        };
+        let mut cache = BrowserTabSearchCache::new().unwrap();
+
+        let old_results = cache.search(&platform, "old", true);
+        assert_eq!(old_results[0].title, "Old Tab");
+
+        *platform.browser_tabs.lock().unwrap() =
+            vec![sample_tab("Fresh Tab", "https://fresh.example/path", 1, 1)];
+
+        let stale_results = cache.search(&platform, "fresh", false);
+        assert!(stale_results.is_empty());
+
+        let fresh_results = cache.search(&platform, "fresh", true);
+        assert_eq!(fresh_results[0].title, "Fresh Tab");
+        assert_eq!(*platform.search_calls.lock().unwrap(), 2);
+    }
+
+    #[test]
+    fn browser_tab_search_cache_returns_all_tabs_for_blank_query() {
+        let platform = StubPlatform {
+            browser_tabs: Mutex::new(vec![
+                sample_tab("Current", "https://current.example", 1, 1),
+                sample_tab("Other", "https://other.example", 2, 1),
+            ]),
+            search_calls: Mutex::new(0),
+        };
+        let mut cache = BrowserTabSearchCache::new().unwrap();
+
+        let results = cache.search(&platform, "", true);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].id,
+            CommandId::from("browser-tab:chrome:window-1:1")
+        );
+        assert_eq!(
+            results[1].id,
+            CommandId::from("browser-tab:chrome:window-2:1")
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/app/state.rs
+++ b/apps/desktop/src-tauri/src/app/state.rs
@@ -52,6 +52,10 @@ impl AppState {
         self.read_launcher().search(query)
     }
 
+    pub fn search_browser_tabs(&self, query: &str) -> Vec<SearchResult> {
+        self.read_launcher().search_browser_tabs(query)
+    }
+
     pub fn execute_command(
         &self,
         request: &CommandExecutionRequest,

--- a/apps/desktop/src-tauri/src/invoke/launcher.rs
+++ b/apps/desktop/src-tauri/src/invoke/launcher.rs
@@ -20,6 +20,17 @@ pub async fn search(
 }
 
 #[tauri::command]
+pub async fn search_browser_tabs(
+    query: String,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<Vec<SearchResult>, String> {
+    let state = Arc::clone(state.inner());
+    tauri::async_runtime::spawn_blocking(move || state.search_browser_tabs(&query))
+        .await
+        .map_err(|error| format!("launcher task failed: {error}"))
+}
+
+#[tauri::command]
 pub async fn execute_command(
     request: CommandExecutionRequest,
     state: tauri::State<'_, Arc<AppState>>,

--- a/apps/desktop/src-tauri/src/invoke/launcher.rs
+++ b/apps/desktop/src-tauri/src/invoke/launcher.rs
@@ -22,10 +22,11 @@ pub async fn search(
 #[tauri::command]
 pub async fn search_browser_tabs(
     query: String,
+    refresh: bool,
     state: tauri::State<'_, Arc<AppState>>,
 ) -> Result<Vec<SearchResult>, String> {
     let state = Arc::clone(state.inner());
-    tauri::async_runtime::spawn_blocking(move || state.search_browser_tabs(&query))
+    tauri::async_runtime::spawn_blocking(move || state.search_browser_tabs(&query, refresh))
         .await
         .map_err(|error| format!("launcher task failed: {error}"))
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             invoke::launcher::search,
+            invoke::launcher::search_browser_tabs,
             invoke::launcher::execute_command,
             invoke::launcher::search_interactive_session,
             invoke::launcher::submit_interactive_session,

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -208,7 +208,7 @@ describe("App", () => {
     fireEvent.change(input, { target: { value: " issue" } });
 
     expect(await screen.findByText("Issue 15")).toBeTruthy();
-    expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("issue");
+    expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("issue", true);
     expect(launcherApi.searchLauncher).not.toHaveBeenCalled();
     expect(input.getAttribute("placeholder")).toBe("Search open Chrome tabs");
     expect(input.getAttribute("data-mode")).toBe("browser_tabs");
@@ -231,8 +231,33 @@ describe("App", () => {
     fireEvent.change(input, { target: { value: " " } });
 
     expect(await screen.findByText("Rayon")).toBeTruthy();
-    expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("");
+    expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("", true);
     expect(input.getAttribute("placeholder")).toBe("Search open Chrome tabs");
+  });
+
+  it("refreshes browser tabs only when entering tab mode", async () => {
+    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
+      searchResult({
+        id: "browser-tab:chrome:window-1:1",
+        title: "Issue 15",
+        subtitle: "github.com",
+        kind: "browser_tab",
+        close_launcher_on_success: true,
+      }),
+    ]);
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: " issue" } });
+    expect(await screen.findByText("Issue 15")).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: " issue 15" } });
+
+    await waitFor(() => {
+      expect(launcherApi.searchBrowserTabs).toHaveBeenNthCalledWith(1, "issue", true);
+      expect(launcherApi.searchBrowserTabs).toHaveBeenNthCalledWith(2, "issue 15", false);
+    });
   });
 
   it("leaves browser tab mode when the leading space is removed", async () => {

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -24,6 +24,7 @@ vi.mock("./features/launcher/api", () => ({
   refreshThemePreference: vi.fn(),
   registerLauncherOpenedListener: vi.fn(),
   resizeLauncher: vi.fn(),
+  searchBrowserTabs: vi.fn(),
   searchInteractiveSession: vi.fn(),
   searchLauncher: vi.fn(),
   submitLauncherInteractiveSelection: vi.fn(),
@@ -112,6 +113,7 @@ describe("App", () => {
     vi.mocked(launcherApi.registerLauncherOpenedListener).mockResolvedValue(vi.fn());
     vi.mocked(launcherApi.resizeLauncher).mockResolvedValue(undefined);
     vi.mocked(launcherApi.searchLauncher).mockResolvedValue([]);
+    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([]);
     vi.mocked(launcherApi.searchInteractiveSession).mockResolvedValue(
       interactiveSession({ results: [] }),
     );
@@ -170,6 +172,95 @@ describe("App", () => {
     await waitFor(() => {
       expect(launcherApi.executeLauncherCommand).toHaveBeenCalledWith("beta", {}, []);
     });
+  });
+
+  it("uses the default launcher search when the query does not start with a space", async () => {
+    vi.mocked(launcherApi.searchLauncher).mockResolvedValue([
+      searchResult({ id: "alpha", title: "Alpha" }),
+    ]);
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: "alpha" } });
+
+    expect(await screen.findByText("Alpha")).toBeTruthy();
+    expect(launcherApi.searchLauncher).toHaveBeenCalledWith("alpha");
+    expect(launcherApi.searchBrowserTabs).not.toHaveBeenCalled();
+    expect(input.getAttribute("placeholder")).toBe("Type a command");
+    expect(input.getAttribute("data-mode")).toBe("default");
+  });
+
+  it("uses browser tab search when the query starts with a space", async () => {
+    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
+      searchResult({
+        id: "browser-tab:chrome:window-1:1",
+        title: "Issue 15",
+        subtitle: "github.com",
+        kind: "browser_tab",
+        close_launcher_on_success: true,
+      }),
+    ]);
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: " issue" } });
+
+    expect(await screen.findByText("Issue 15")).toBeTruthy();
+    expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("issue");
+    expect(launcherApi.searchLauncher).not.toHaveBeenCalled();
+    expect(input.getAttribute("placeholder")).toBe("Search open Chrome tabs");
+    expect(input.getAttribute("data-mode")).toBe("browser_tabs");
+  });
+
+  it("shows all tabs when the query is only a leading space", async () => {
+    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
+      searchResult({
+        id: "browser-tab:chrome:window-1:1",
+        title: "Rayon",
+        subtitle: "github.com",
+        kind: "browser_tab",
+        close_launcher_on_success: true,
+      }),
+    ]);
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: " " } });
+
+    expect(await screen.findByText("Rayon")).toBeTruthy();
+    expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("");
+    expect(input.getAttribute("placeholder")).toBe("Search open Chrome tabs");
+  });
+
+  it("leaves browser tab mode when the leading space is removed", async () => {
+    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
+      searchResult({
+        id: "browser-tab:chrome:window-1:1",
+        title: "Issue 15",
+        subtitle: "github.com",
+        kind: "browser_tab",
+        close_launcher_on_success: true,
+      }),
+    ]);
+    vi.mocked(launcherApi.searchLauncher).mockResolvedValue([
+      searchResult({ id: "echo", title: "Echo" }),
+    ]);
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: " issue" } });
+    expect(await screen.findByText("Issue 15")).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: "issue" } });
+
+    expect(await screen.findByText("Echo")).toBeTruthy();
+    expect(launcherApi.searchLauncher).toHaveBeenCalledWith("issue");
+    expect(input.getAttribute("placeholder")).toBe("Type a command");
+    expect(input.getAttribute("data-mode")).toBe("default");
   });
 
   it("validates pending argument entry before executing the command", async () => {

--- a/apps/desktop/src/commandExecution.ts
+++ b/apps/desktop/src/commandExecution.ts
@@ -16,7 +16,7 @@ export type SearchResult = {
   title: string;
   subtitle: string | null;
   icon_path: string | null;
-  kind: "command" | "application" | "bookmark";
+  kind: "command" | "application" | "bookmark" | "browser_tab";
   owner_plugin_id: string | null;
   keywords: string[];
   starts_interactive_session: boolean;

--- a/apps/desktop/src/features/launcher/Launcher.tsx
+++ b/apps/desktop/src/features/launcher/Launcher.tsx
@@ -15,6 +15,7 @@ export function Launcher() {
 
       <LauncherSearchInput
         inputRef={controller.inputRef}
+        mode={controller.inputMode}
         value={controller.query}
         placeholder={controller.placeholder}
         onChange={controller.onQueryChange}

--- a/apps/desktop/src/features/launcher/api.ts
+++ b/apps/desktop/src/features/launcher/api.ts
@@ -25,8 +25,8 @@ export async function searchLauncher(query: string) {
   return invoke<SearchResult[]>("search", { query });
 }
 
-export async function searchBrowserTabs(query: string) {
-  return invoke<SearchResult[]>("search_browser_tabs", { query });
+export async function searchBrowserTabs(query: string, refresh = false) {
+  return invoke<SearchResult[]>("search_browser_tabs", { query, refresh });
 }
 
 export async function searchInteractiveSession(sessionId: string, query: string) {

--- a/apps/desktop/src/features/launcher/api.ts
+++ b/apps/desktop/src/features/launcher/api.ts
@@ -25,6 +25,10 @@ export async function searchLauncher(query: string) {
   return invoke<SearchResult[]>("search", { query });
 }
 
+export async function searchBrowserTabs(query: string) {
+  return invoke<SearchResult[]>("search_browser_tabs", { query });
+}
+
 export async function searchInteractiveSession(sessionId: string, query: string) {
   return invoke<InteractiveSessionState>("search_interactive_session", {
     request: {

--- a/apps/desktop/src/features/launcher/components/LauncherSearchInput.tsx
+++ b/apps/desktop/src/features/launcher/components/LauncherSearchInput.tsx
@@ -1,15 +1,18 @@
 import type { KeyboardEventHandler, Ref, RefObject } from "react";
 
 import { Input } from "@/components/ui/input";
+import type { LauncherInputMode } from "@/features/launcher/types";
 
 export function LauncherSearchInput({
   inputRef,
+  mode,
   onChange,
   onKeyDown,
   placeholder,
   value,
 }: {
   inputRef: RefObject<HTMLInputElement | null>;
+  mode: LauncherInputMode;
   onChange: (value: string) => void;
   onKeyDown: KeyboardEventHandler<HTMLInputElement>;
   placeholder: string;
@@ -18,12 +21,18 @@ export function LauncherSearchInput({
   return (
     <Input
       ref={inputRef as Ref<HTMLInputElement>}
+      data-mode={mode}
       value={value}
       onChange={(event) => {
         onChange(event.currentTarget.value);
       }}
       onKeyDown={onKeyDown}
       placeholder={placeholder}
+      className={
+        mode === "browser_tabs"
+          ? "border-[rgba(37,99,235,0.42)] bg-[rgba(234,244,255,0.9)] focus-visible:border-[rgba(37,99,235,0.72)] focus-visible:bg-[rgba(239,247,255,0.98)] focus-visible:ring-[rgba(37,99,235,0.16)]"
+          : undefined
+      }
       spellCheck={false}
       autoCapitalize="off"
       autoCorrect="off"

--- a/apps/desktop/src/features/launcher/copy.ts
+++ b/apps/desktop/src/features/launcher/copy.ts
@@ -31,6 +31,9 @@ export function getInteractiveSubmitHint(session: InteractiveSessionState): stri
 }
 
 export function getSearchResultKind(result: SearchResult): string {
+  if (result.kind === "browser_tab") {
+    return "Tab";
+  }
   if (result.kind === "application") {
     return "App";
   }

--- a/apps/desktop/src/features/launcher/types.ts
+++ b/apps/desktop/src/features/launcher/types.ts
@@ -2,6 +2,8 @@ import type { KeyboardEventHandler, RefObject } from "react";
 
 import type { PendingExecution } from "@/commandExecution";
 
+export type LauncherInputMode = "default" | "browser_tabs";
+
 export type LauncherResultItemViewModel = {
   id: string;
   title: string;
@@ -34,6 +36,7 @@ export type LauncherController = {
   inputRef: RefObject<HTMLInputElement | null>;
   query: string;
   placeholder: string;
+  inputMode: LauncherInputMode;
   onQueryChange: (nextQuery: string) => void;
   onKeyDown: KeyboardEventHandler<HTMLInputElement>;
   header: LauncherHeaderViewModel;

--- a/apps/desktop/src/features/launcher/useLauncherController.ts
+++ b/apps/desktop/src/features/launcher/useLauncherController.ts
@@ -53,6 +53,7 @@ export function useLauncherController(): LauncherController {
   const resultItemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const interactiveSearchRequestId = useRef(0);
   const optimisticSessionCounter = useRef(0);
+  const previousQueryRef = useRef("");
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [interactiveSession, setInteractiveSession] = useState<InteractiveSessionState | null>(
@@ -132,11 +133,15 @@ export function useLauncherController(): LauncherController {
   }, []);
 
   useEffect(() => {
+    const previousQuery = previousQueryRef.current;
+
     if (!shouldRunSearch({ query, pendingExecution, interactiveSession })) {
       return;
     }
 
     const searchMode = getLauncherInputMode(query);
+    const refreshBrowserTabs =
+      searchMode === "browser_tabs" && getLauncherInputMode(previousQuery) !== "browser_tabs";
     let cancelled = false;
 
     async function runSearch() {
@@ -144,7 +149,10 @@ export function useLauncherController(): LauncherController {
         const nextResults =
           searchMode === "browser_tabs"
             ? {
-                results: await searchBrowserTabs(normalizeBrowserTabQuery(query)),
+                results: await searchBrowserTabs(
+                  normalizeBrowserTabQuery(query),
+                  refreshBrowserTabs,
+                ),
                 inlineFallbackArgv: [],
               }
             : await resolveLauncherSearch(query);
@@ -180,6 +188,10 @@ export function useLauncherController(): LauncherController {
       cancelled = true;
     };
   }, [interactiveSession, pendingExecution, query]);
+
+  useEffect(() => {
+    previousQueryRef.current = query;
+  }, [query]);
 
   useEffect(() => {
     if (!interactiveSessionId || interactiveSessionId.startsWith("pending:")) {
@@ -706,7 +718,7 @@ export function useLauncherController(): LauncherController {
         ? interactiveSession.input_placeholder
         : inputMode === "browser_tabs"
           ? "Search open Chrome tabs"
-        : "Type a command",
+          : "Type a command",
     inputMode,
     onQueryChange,
     onKeyDown,

--- a/apps/desktop/src/features/launcher/useLauncherController.ts
+++ b/apps/desktop/src/features/launcher/useLauncherController.ts
@@ -24,6 +24,7 @@ import {
   hideLauncherAndRestoreFocus,
   refreshThemePreference,
   registerLauncherOpenedListener,
+  searchBrowserTabs,
   searchInteractiveSession,
   searchLauncher,
   submitLauncherInteractiveSelection,
@@ -42,6 +43,7 @@ import type {
   LauncherController,
   LauncherFooterViewModel,
   LauncherHeaderViewModel,
+  LauncherInputMode,
   LauncherResultItemViewModel,
 } from "./types";
 
@@ -134,11 +136,18 @@ export function useLauncherController(): LauncherController {
       return;
     }
 
+    const searchMode = getLauncherInputMode(query);
     let cancelled = false;
 
     async function runSearch() {
       try {
-        const nextResults = await resolveLauncherSearch(query);
+        const nextResults =
+          searchMode === "browser_tabs"
+            ? {
+                results: await searchBrowserTabs(normalizeBrowserTabQuery(query)),
+                inlineFallbackArgv: [],
+              }
+            : await resolveLauncherSearch(query);
         if (cancelled) {
           return;
         }
@@ -571,6 +580,8 @@ export function useLauncherController(): LauncherController {
   };
 
   const activeArgument = currentArgument(pendingExecution);
+  const inputMode: LauncherInputMode =
+    pendingExecution || interactiveSession ? "default" : getLauncherInputMode(query);
   const viewState = getLauncherViewState({
     query,
     results,
@@ -693,7 +704,10 @@ export function useLauncherController(): LauncherController {
         : activeArgument.label
       : interactiveSession
         ? interactiveSession.input_placeholder
+        : inputMode === "browser_tabs"
+          ? "Search open Chrome tabs"
         : "Type a command",
+    inputMode,
     onQueryChange,
     onKeyDown,
     header,
@@ -726,6 +740,14 @@ export function useLauncherController(): LauncherController {
     },
     pendingExecution,
   };
+}
+
+function getLauncherInputMode(query: string): LauncherInputMode {
+  return query.startsWith(" ") ? "browser_tabs" : "default";
+}
+
+function normalizeBrowserTabQuery(query: string): string {
+  return query.slice(1).trim();
 }
 
 async function resolveLauncherSearch(query: string): Promise<{

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -1,8 +1,8 @@
 use rayon_db::{SearchIndexStats, TantivySearchIndex};
 use rayon_platform::MacOsAppManager;
 use rayon_types::{
-    BookmarkDefinition, CommandId, CommandInputMode, InstalledApp, ProcessMatch, SearchResult,
-    SearchResultKind, SearchableItemDocument,
+    BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandId, CommandInputMode, InstalledApp,
+    ProcessMatch, SearchResult, SearchResultKind, SearchableItemDocument,
 };
 use std::collections::HashMap;
 
@@ -10,6 +10,8 @@ pub trait AppPlatform: Send + Sync {
     fn discover_apps(&self) -> Result<Vec<InstalledApp>, String>;
     fn launch_app(&self, app: &InstalledApp) -> Result<(), String>;
     fn open_url(&self, url: &str) -> Result<(), String>;
+    fn search_browser_tabs(&self, query: &str) -> Result<Vec<BrowserTab>, String>;
+    fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String>;
     fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String>;
     fn terminate_process(&self, pid: u32) -> Result<(), String>;
 }
@@ -31,6 +33,14 @@ impl AppPlatform for MacOsAppManager {
 
     fn open_url(&self, url: &str) -> Result<(), String> {
         MacOsAppManager::open_url(self, url)
+    }
+
+    fn search_browser_tabs(&self, query: &str) -> Result<Vec<BrowserTab>, String> {
+        MacOsAppManager::search_browser_tabs(self, query)
+    }
+
+    fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String> {
+        MacOsAppManager::focus_browser_tab(self, target)
     }
 
     fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String> {

--- a/crates/core/src/launcher/execution.rs
+++ b/crates/core/src/launcher/execution.rs
@@ -4,8 +4,8 @@ use super::state::{next_session_id, write_app_catalog, write_interactive_session
 use crate::catalog::AppCatalog;
 use crate::commands::APP_REINDEX_COMMAND_ID;
 use rayon_types::{
-    CommandExecutionRequest, CommandExecutionResult, CommandId, CommandInvocationResult,
-    InteractiveSessionMetadata, InteractiveSessionState,
+    parse_browser_tab_command_id, CommandExecutionRequest, CommandExecutionResult, CommandId,
+    CommandInvocationResult, InteractiveSessionMetadata, InteractiveSessionState,
 };
 
 impl LauncherService {
@@ -22,6 +22,13 @@ impl LauncherService {
 
         if request.command_id.as_str().starts_with("app:macos:") {
             let result = self.launch_app(&request.command_id)?;
+            return Ok(CommandInvocationResult::Completed {
+                output: result.output,
+            });
+        }
+
+        if let Some(target) = parse_browser_tab_command_id(&request.command_id) {
+            let result = self.focus_browser_tab(&target)?;
             return Ok(CommandInvocationResult::Completed {
                 output: result.output,
             });
@@ -134,6 +141,19 @@ impl LauncherService {
 
         Ok(CommandExecutionResult {
             output: format!("opened {}", bookmark.title),
+        })
+    }
+
+    fn focus_browser_tab(
+        &self,
+        target: &rayon_types::BrowserTabTarget,
+    ) -> Result<CommandExecutionResult, LauncherError> {
+        self.platform
+            .focus_browser_tab(target)
+            .map_err(LauncherError::Platform)?;
+
+        Ok(CommandExecutionResult {
+            output: "focused Chrome tab".into(),
         })
     }
 }

--- a/crates/core/src/launcher/search.rs
+++ b/crates/core/src/launcher/search.rs
@@ -1,12 +1,13 @@
 use super::service::LauncherService;
 use super::state::read_app_catalog;
 use rayon_db::SearchIndexStats;
-use rayon_types::SearchResult;
+use rayon_types::{CommandInputMode, SearchResult, SearchResultKind};
 
 const SEARCH_LIMIT: usize = 20;
 
 impl LauncherService {
     pub fn search(&self, query: &str) -> Vec<SearchResult> {
+        let mut results = self.browser_tab_results(query);
         let item_ids = match self.search_index.search_item_ids(query, SEARCH_LIMIT) {
             Ok(item_ids) => item_ids,
             Err(error) => {
@@ -20,10 +21,17 @@ impl LauncherService {
         search_results.extend(app_results);
         search_results.extend(self.bookmark_catalog.search_results_by_id());
 
-        item_ids
-            .into_iter()
-            .filter_map(|item_id| search_results.get(&item_id).cloned())
-            .collect()
+        for item_id in item_ids {
+            if results.len() >= SEARCH_LIMIT {
+                break;
+            }
+
+            if let Some(result) = search_results.get(&item_id).cloned() {
+                results.push(result);
+            }
+        }
+
+        results
     }
 
     pub fn search_enabled(&self) -> bool {
@@ -36,5 +44,34 @@ impl LauncherService {
         documents.extend(app_documents);
         documents.extend(self.bookmark_catalog.searchable_documents());
         self.search_index.replace_items(&documents)
+    }
+
+    fn browser_tab_results(&self, query: &str) -> Vec<SearchResult> {
+        match self.platform.search_browser_tabs(query) {
+            Ok(tabs) => tabs
+                .into_iter()
+                .take(SEARCH_LIMIT)
+                .map(|tab| {
+                    let subtitle = tab.subtitle();
+                    SearchResult {
+                        id: tab.command_id(),
+                        title: tab.title,
+                        subtitle: Some(subtitle),
+                        icon_path: None,
+                        kind: SearchResultKind::BrowserTab,
+                        owner_plugin_id: None,
+                        keywords: Vec::new(),
+                        starts_interactive_session: false,
+                        close_launcher_on_success: true,
+                        input_mode: CommandInputMode::Structured,
+                        arguments: Vec::new(),
+                    }
+                })
+                .collect(),
+            Err(error) => {
+                eprintln!("browser tab search failed: {error}");
+                Vec::new()
+            }
+        }
     }
 }

--- a/crates/core/src/launcher/search.rs
+++ b/crates/core/src/launcher/search.rs
@@ -7,7 +7,6 @@ const SEARCH_LIMIT: usize = 20;
 
 impl LauncherService {
     pub fn search(&self, query: &str) -> Vec<SearchResult> {
-        let mut results = self.browser_tab_results(query);
         let item_ids = match self.search_index.search_item_ids(query, SEARCH_LIMIT) {
             Ok(item_ids) => item_ids,
             Err(error) => {
@@ -21,17 +20,18 @@ impl LauncherService {
         search_results.extend(app_results);
         search_results.extend(self.bookmark_catalog.search_results_by_id());
 
+        let mut results = Vec::new();
         for item_id in item_ids {
-            if results.len() >= SEARCH_LIMIT {
-                break;
-            }
-
             if let Some(result) = search_results.get(&item_id).cloned() {
                 results.push(result);
             }
         }
 
         results
+    }
+
+    pub fn search_browser_tabs(&self, query: &str) -> Vec<SearchResult> {
+        self.browser_tab_results(query)
     }
 
     pub fn search_enabled(&self) -> bool {

--- a/crates/core/src/launcher/tests.rs
+++ b/crates/core/src/launcher/tests.rs
@@ -65,7 +65,7 @@ fn aggregate_search_uses_shared_index_ids() {
 
 #[allow(clippy::unwrap_used)]
 #[test]
-fn search_prioritizes_matching_browser_tabs() {
+fn aggregate_search_does_not_include_browser_tabs() {
     let platform = Arc::new(StubPlatform {
         apps: vec![rayon_types::InstalledApp {
             id: CommandId::from("app:macos:com.example.arc"),
@@ -92,6 +92,40 @@ fn search_prioritizes_matching_browser_tabs() {
 
     let results = launcher.search("arc");
 
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].kind, SearchResultKind::Command);
+}
+
+#[allow(clippy::unwrap_used)]
+#[test]
+fn search_browser_tabs_returns_matching_browser_tabs() {
+    let platform = Arc::new(StubPlatform {
+        apps: vec![rayon_types::InstalledApp {
+            id: CommandId::from("app:macos:com.example.arc"),
+            title: "Arc".into(),
+            bundle_identifier: Some("com.example.arc".into()),
+            path: "/Applications/Arc.app".into(),
+        }],
+        launched: Mutex::new(Vec::new()),
+        opened_urls: Mutex::new(Vec::new()),
+        browser_tabs: Mutex::new(vec![BrowserTab {
+            browser: "chrome".into(),
+            window_id: "window-1".into(),
+            window_index: 1,
+            active_tab_index: 2,
+            tab_index: 2,
+            title: "Arc Docs".into(),
+            url: "https://example.com/arc".into(),
+        }]),
+        focused_browser_tabs: Mutex::new(Vec::new()),
+        process_search_results: Mutex::new(Vec::new()),
+        terminated_pids: Mutex::new(Vec::new()),
+    });
+    let launcher = launcher_with_platform(platform, vec![String::from("echo")]);
+
+    let results = launcher.search_browser_tabs("arc");
+
+    assert_eq!(results.len(), 1);
     assert_eq!(results[0].kind, SearchResultKind::BrowserTab);
     assert_eq!(results[0].title, "Arc Docs");
     assert!(results[0].close_launcher_on_success);

--- a/crates/core/src/launcher/tests.rs
+++ b/crates/core/src/launcher/tests.rs
@@ -5,12 +5,46 @@ use crate::test_support::{
 };
 use rayon_db::SearchIndexStats;
 use rayon_types::{
-    BookmarkDefinition, CommandExecutionRequest, CommandId, CommandInvocationResult,
-    InteractiveSessionQueryRequest, InteractiveSessionSubmitRequest,
+    BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandExecutionRequest, CommandId,
+    CommandInvocationResult, InteractiveSessionQueryRequest, InteractiveSessionSubmitRequest,
     InteractiveSessionSubmitResult, SearchResultKind,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+
+#[allow(clippy::unwrap_used)]
+fn launcher_with_platform(
+    platform: Arc<StubPlatform>,
+    search_results: Vec<String>,
+) -> LauncherService {
+    let mut registry = CommandRegistry::new();
+    registry.register_provider(Arc::new(TestProvider)).unwrap();
+
+    let index = Arc::new(StubSearchIndex {
+        configured: true,
+        search_results,
+        stats: SearchIndexStats {
+            discovered_count: 0,
+            indexed_count: 5,
+            skipped_count: 0,
+        },
+        last_documents: Mutex::new(Vec::new()),
+    });
+
+    LauncherService::new(
+        registry,
+        vec![BookmarkDefinition {
+            id: CommandId::from("bookmark:github"),
+            title: "GitHub".into(),
+            subtitle: Some("https://github.com".into()),
+            owner_plugin_id: "user.bookmarks".into(),
+            url: "https://github.com".into(),
+            keywords: vec!["code".into()],
+        }],
+        platform,
+        index,
+    )
+}
 
 #[allow(clippy::unwrap_used)]
 #[test]
@@ -27,6 +61,40 @@ fn aggregate_search_uses_shared_index_ids() {
     assert_eq!(results[0].kind, SearchResultKind::Command);
     assert_eq!(results[1].kind, SearchResultKind::Application);
     assert_eq!(results[2].kind, SearchResultKind::Bookmark);
+}
+
+#[allow(clippy::unwrap_used)]
+#[test]
+fn search_prioritizes_matching_browser_tabs() {
+    let platform = Arc::new(StubPlatform {
+        apps: vec![rayon_types::InstalledApp {
+            id: CommandId::from("app:macos:com.example.arc"),
+            title: "Arc".into(),
+            bundle_identifier: Some("com.example.arc".into()),
+            path: "/Applications/Arc.app".into(),
+        }],
+        launched: Mutex::new(Vec::new()),
+        opened_urls: Mutex::new(Vec::new()),
+        browser_tabs: Mutex::new(vec![BrowserTab {
+            browser: "chrome".into(),
+            window_id: "window-1".into(),
+            window_index: 1,
+            active_tab_index: 2,
+            tab_index: 2,
+            title: "Arc Docs".into(),
+            url: "https://example.com/arc".into(),
+        }]),
+        focused_browser_tabs: Mutex::new(Vec::new()),
+        process_search_results: Mutex::new(Vec::new()),
+        terminated_pids: Mutex::new(Vec::new()),
+    });
+    let launcher = launcher_with_platform(platform, vec![String::from("echo")]);
+
+    let results = launcher.search("arc");
+
+    assert_eq!(results[0].kind, SearchResultKind::BrowserTab);
+    assert_eq!(results[0].title, "Arc Docs");
+    assert!(results[0].close_launcher_on_success);
 }
 
 #[allow(clippy::unwrap_used)]
@@ -88,6 +156,54 @@ fn execute_routes_bookmark_ids_to_platform_url_opener() {
         result,
         CommandInvocationResult::Completed {
             output: "opened GitHub".into()
+        }
+    );
+}
+
+#[allow(clippy::unwrap_used)]
+#[test]
+fn execute_routes_browser_tab_ids_to_platform_focus() {
+    let platform = Arc::new(StubPlatform {
+        apps: Vec::new(),
+        launched: Mutex::new(Vec::new()),
+        opened_urls: Mutex::new(Vec::new()),
+        browser_tabs: Mutex::new(vec![BrowserTab {
+            browser: "chrome".into(),
+            window_id: "window-1".into(),
+            window_index: 1,
+            active_tab_index: 4,
+            tab_index: 4,
+            title: "Issue 15".into(),
+            url: "https://github.com/alexandrelam/rayon/issues/15".into(),
+        }]),
+        focused_browser_tabs: Mutex::new(Vec::new()),
+        process_search_results: Mutex::new(Vec::new()),
+        terminated_pids: Mutex::new(Vec::new()),
+    });
+    let launcher = launcher_with_platform(platform.clone(), vec![]);
+
+    let result = launcher
+        .execute_command(&CommandExecutionRequest {
+            command_id: CommandId::from("browser-tab:chrome:window-1:4"),
+            argv: Vec::new(),
+            arguments: HashMap::new(),
+        })
+        .unwrap();
+
+    assert_eq!(
+        result,
+        CommandInvocationResult::Completed {
+            output: "focused Chrome tab".into()
+        }
+    );
+
+    let focused = &platform.focused_browser_tabs.lock().unwrap()[0];
+    assert_eq!(
+        focused,
+        &BrowserTabTarget {
+            browser: "chrome".into(),
+            window_id: "window-1".into(),
+            tab_index: 4,
         }
     );
 }
@@ -175,6 +291,8 @@ fn completed_interactive_submit_removes_active_session() {
         apps: Vec::new(),
         launched: Mutex::new(Vec::new()),
         opened_urls: Mutex::new(Vec::new()),
+        browser_tabs: Mutex::new(Vec::new()),
+        focused_browser_tabs: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -240,6 +358,8 @@ fn startup_reindexes_commands_and_apps() {
         }],
         launched: Mutex::new(Vec::new()),
         opened_urls: Mutex::new(Vec::new()),
+        browser_tabs: Mutex::new(Vec::new()),
+        focused_browser_tabs: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });

--- a/crates/core/src/test_support.rs
+++ b/crates/core/src/test_support.rs
@@ -6,9 +6,10 @@ use crate::{
 };
 use rayon_db::SearchIndexStats;
 use rayon_types::{
-    BookmarkDefinition, CommandArgumentDefinition, CommandArgumentType, CommandDefinition,
-    CommandExecutionRequest, CommandExecutionResult, CommandId, CommandInputMode, InstalledApp,
-    InteractiveSessionMetadata, InteractiveSessionResult, ProcessMatch, SearchableItemDocument,
+    BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandArgumentDefinition,
+    CommandArgumentType, CommandDefinition, CommandExecutionRequest, CommandExecutionResult,
+    CommandId, CommandInputMode, InstalledApp, InteractiveSessionMetadata,
+    InteractiveSessionResult, ProcessMatch, SearchableItemDocument,
 };
 use std::sync::{Arc, Mutex};
 
@@ -175,6 +176,8 @@ pub(crate) struct StubPlatform {
     pub apps: Vec<InstalledApp>,
     pub launched: Mutex<Vec<String>>,
     pub opened_urls: Mutex<Vec<String>>,
+    pub browser_tabs: Mutex<Vec<BrowserTab>>,
+    pub focused_browser_tabs: Mutex<Vec<BrowserTabTarget>>,
     pub process_search_results: Mutex<Vec<ProcessMatch>>,
     pub terminated_pids: Mutex<Vec<u32>>,
 }
@@ -191,6 +194,26 @@ impl AppPlatform for StubPlatform {
 
     fn open_url(&self, url: &str) -> Result<(), String> {
         self.opened_urls.lock().unwrap().push(url.to_string());
+        Ok(())
+    }
+
+    fn search_browser_tabs(&self, query: &str) -> Result<Vec<BrowserTab>, String> {
+        let normalized_query = query.trim().to_lowercase();
+        Ok(self
+            .browser_tabs
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|tab| tab.search_text().contains(&normalized_query))
+            .cloned()
+            .collect())
+    }
+
+    fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String> {
+        self.focused_browser_tabs
+            .lock()
+            .unwrap()
+            .push(target.clone());
         Ok(())
     }
 
@@ -242,6 +265,8 @@ pub(crate) fn build_launcher_service(search_results: Vec<String>) -> LauncherSer
         }],
         launched: Mutex::new(Vec::new()),
         opened_urls: Mutex::new(Vec::new()),
+        browser_tabs: Mutex::new(Vec::new()),
+        focused_browser_tabs: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -250,6 +250,7 @@ fn search_kind(kind: SearchResultKind) -> &'static str {
         SearchResultKind::Command => "command",
         SearchResultKind::Application => "application",
         SearchResultKind::Bookmark => "bookmark",
+        SearchResultKind::BrowserTab => "browser_tab",
     }
 }
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -5,7 +5,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tantivy::collector::TopDocs;
 use tantivy::directory::error::OpenDirectoryError;
-use tantivy::directory::MmapDirectory;
+use tantivy::directory::Directory;
+use tantivy::directory::{MmapDirectory, RamDirectory};
 use tantivy::query::{AllQuery, QueryParser};
 use tantivy::schema::{Field, Schema, Value, STORED, STRING, TEXT};
 use tantivy::{doc, Index, IndexReader, TantivyDocument};
@@ -95,7 +96,7 @@ pub struct TantivySearchIndex {
     index: Index,
     reader: IndexReader,
     fields: SearchIndexFields,
-    path: PathBuf,
+    path: Option<PathBuf>,
 }
 
 impl TantivySearchIndex {
@@ -117,7 +118,19 @@ impl TantivySearchIndex {
             index,
             reader,
             fields,
-            path,
+            path: Some(path),
+        })
+    }
+
+    pub fn create_in_memory() -> Result<Self, TantivySearchIndexError> {
+        let (schema, fields) = SearchIndexFields::build_schema();
+        let (index, reader) = Self::open_index_in_directory(RamDirectory::create(), schema)?;
+
+        Ok(Self {
+            index,
+            reader,
+            fields,
+            path: None,
         })
     }
 
@@ -202,8 +215,8 @@ impl TantivySearchIndex {
         })
     }
 
-    pub fn path(&self) -> &Path {
-        &self.path
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
     }
 
     fn open_index(
@@ -211,6 +224,13 @@ impl TantivySearchIndex {
         schema: Schema,
     ) -> Result<(Index, IndexReader), TantivySearchIndexError> {
         let directory = MmapDirectory::open(path)?;
+        Self::open_index_in_directory(directory, schema)
+    }
+
+    fn open_index_in_directory<D: Directory + 'static>(
+        directory: D,
+        schema: Schema,
+    ) -> Result<(Index, IndexReader), TantivySearchIndexError> {
         let index = Index::open_or_create(directory, schema)?;
         let reader = index.reader()?;
         Ok((index, reader))
@@ -492,5 +512,24 @@ mod tests {
 
         let results = reopened.search_item_ids("fresh", 10).unwrap();
         assert_eq!(results, vec![String::from("fresh")]);
+    }
+
+    #[test]
+    fn searches_in_memory_indexes() {
+        let index = TantivySearchIndex::create_in_memory().unwrap();
+        index
+            .replace_items(&[searchable_item(
+                "browser-tab:chrome:window-1:2",
+                SearchResultKind::BrowserTab,
+                "Issue 15",
+                Some("Google Chrome · https://github.com/alexandrelam/rayon/issues/15"),
+                None,
+                "Issue 15 https://github.com/alexandrelam/rayon/issues/15 chrome",
+            )])
+            .unwrap();
+
+        let results = index.search_item_ids("rayon issue", 10).unwrap();
+        assert_eq!(results, vec![String::from("browser-tab:chrome:window-1:2")]);
+        assert!(index.path().is_none());
     }
 }

--- a/crates/features/src/github.rs
+++ b/crates/features/src/github.rs
@@ -307,7 +307,7 @@ fn stderr_or_stdout(output: &std::process::Output) -> Option<String> {
 mod tests {
     use super::*;
     use rayon_core::InteractiveSessionSubmitOutcome;
-    use rayon_types::{CommandId, InstalledApp, ProcessMatch};
+    use rayon_types::{BrowserTab, BrowserTabTarget, CommandId, InstalledApp, ProcessMatch};
     use std::collections::VecDeque;
 
     #[derive(Default)]
@@ -326,6 +326,14 @@ mod tests {
 
         fn open_url(&self, url: &str) -> Result<(), String> {
             self.opened_urls.lock().unwrap().push(url.to_string());
+            Ok(())
+        }
+
+        fn search_browser_tabs(&self, _query: &str) -> Result<Vec<BrowserTab>, String> {
+            Ok(Vec::new())
+        }
+
+        fn focus_browser_tab(&self, _target: &BrowserTabTarget) -> Result<(), String> {
             Ok(())
         }
 

--- a/crates/features/src/lib.rs
+++ b/crates/features/src/lib.rs
@@ -27,8 +27,7 @@ pub fn built_in_providers(deps: BuiltInDependencies) -> Vec<Arc<dyn CommandProvi
 mod tests {
     use super::*;
     use rayon_core::CommandRegistry;
-    use rayon_types::CommandId;
-    use rayon_types::ProcessMatch;
+    use rayon_types::{BrowserTab, BrowserTabTarget, CommandId, ProcessMatch};
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -44,6 +43,14 @@ mod tests {
         }
 
         fn open_url(&self, _url: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn search_browser_tabs(&self, _query: &str) -> Result<Vec<BrowserTab>, String> {
+            Ok(Vec::new())
+        }
+
+        fn focus_browser_tab(&self, _target: &BrowserTabTarget) -> Result<(), String> {
             Ok(())
         }
 

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -7,6 +7,8 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 const APPLICATIONS_DIR: &str = "/Applications";
 const SYSTEM_APPLICATIONS_DIR: &str = "/System/Applications";
@@ -90,18 +92,33 @@ impl MacOsAppManager {
             return Err(format!("unsupported browser target: {}", target.browser));
         }
 
-        let output = Command::new("/usr/bin/osascript")
-            .arg("-e")
-            .arg(chrome_focus_tab_script(&target.window_id, target.tab_index))
-            .output()
-            .map_err(|error| format!("failed to focus Chrome tab: {error}"))?;
-
-        if output.status.success() {
-            Ok(())
-        } else {
-            Err(stderr_or_stdout(&output)
-                .unwrap_or_else(|| "failed to focus Chrome tab".to_string()))
+        let status = Command::new("/usr/bin/open")
+            .args(["-a", "Google Chrome"])
+            .status()
+            .map_err(|error| format!("failed to activate Google Chrome: {error}"))?;
+        if !status.success() {
+            return Err("failed to activate Google Chrome".to_string());
         }
+
+        let mut last_error = None;
+        for attempt in 0..4 {
+            let output = Command::new("/usr/bin/osascript")
+                .arg("-e")
+                .arg(chrome_focus_tab_script(&target.window_id, target.tab_index))
+                .output()
+                .map_err(|error| format!("failed to focus Chrome tab: {error}"))?;
+
+            if output.status.success() {
+                return Ok(());
+            }
+
+            last_error = stderr_or_stdout(&output);
+            if attempt < 3 {
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| "failed to focus Chrome tab".to_string()))
     }
 
     pub fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String> {
@@ -310,13 +327,21 @@ tell application "System Events"
 end tell
 
 tell application "Google Chrome"
+    if not (exists (first window whose id is "{}")) then
+        error "Chrome window not found"
+    end if
     set targetWindow to first window whose id is "{}"
+    if (count of tabs of targetWindow) < {} then
+        error "Chrome tab not found"
+    end if
     set index of targetWindow to 1
     set active tab index of targetWindow to {}
     activate
 end tell
 "#,
         apple_script_string(window_id),
+        apple_script_string(window_id),
+        tab_index,
         tab_index
     )
 }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -1,5 +1,5 @@
 use plist::Value;
-use rayon_types::{CommandId, InstalledApp, ProcessMatch};
+use rayon_types::{BrowserTab, BrowserTabTarget, CommandId, InstalledApp, ProcessMatch};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -10,6 +10,8 @@ use std::process::Command;
 
 const APPLICATIONS_DIR: &str = "/Applications";
 const SYSTEM_APPLICATIONS_DIR: &str = "/System/Applications";
+const APPLE_SCRIPT_FIELD_SEPARATOR: char = '\u{001f}';
+const APPLE_SCRIPT_RECORD_SEPARATOR: char = '\u{001e}';
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MacOsAppManager;
@@ -63,6 +65,46 @@ impl MacOsAppManager {
             Ok(())
         } else {
             Err(format!("failed to open {url}"))
+        }
+    }
+
+    pub fn search_browser_tabs(&self, query: &str) -> Result<Vec<BrowserTab>, String> {
+        let trimmed_query = query.trim();
+        if trimmed_query.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let output = Command::new("/usr/bin/osascript")
+            .arg("-e")
+            .arg(chrome_tabs_list_script())
+            .output()
+            .map_err(|error| format!("failed to list Chrome tabs: {error}"))?;
+
+        if !output.status.success() {
+            return Err(stderr_or_stdout(&output)
+                .unwrap_or_else(|| "failed to list Chrome tabs".to_string()));
+        }
+
+        let tabs = parse_chrome_tabs_output(&String::from_utf8_lossy(&output.stdout))?;
+        Ok(filter_browser_tabs(&tabs, trimmed_query))
+    }
+
+    pub fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String> {
+        if target.browser != "chrome" {
+            return Err(format!("unsupported browser target: {}", target.browser));
+        }
+
+        let output = Command::new("/usr/bin/osascript")
+            .arg("-e")
+            .arg(chrome_focus_tab_script(&target.window_id, target.tab_index))
+            .output()
+            .map_err(|error| format!("failed to focus Chrome tab: {error}"))?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(stderr_or_stdout(&output)
+                .unwrap_or_else(|| "failed to focus Chrome tab".to_string()))
         }
     }
 
@@ -209,6 +251,165 @@ fn is_app_bundle(path: &Path) -> bool {
 
 fn compare_app_priority(left: &InstalledApp, right: &InstalledApp) -> Ordering {
     app_path_rank(&left.path).cmp(&app_path_rank(&right.path))
+}
+
+fn stderr_or_stdout(output: &std::process::Output) -> Option<String> {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return Some(stderr);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return Some(stdout);
+    }
+
+    None
+}
+
+fn chrome_tabs_list_script() -> &'static str {
+    r#"
+set fieldSep to character id 31
+set recordSep to character id 30
+
+tell application "System Events"
+    if not (exists process "Google Chrome") then
+        return ""
+    end if
+end tell
+
+tell application "Google Chrome"
+    set rows to {}
+    repeat with w in every window
+        set windowId to (id of w as text)
+        set windowIndex to (index of w as text)
+        set activeIndex to (active tab index of w as text)
+        set tabIndex to 0
+        repeat with t in every tab of w
+            set tabIndex to tabIndex + 1
+            set rowParts to {windowId, windowIndex, activeIndex, (tabIndex as text), (title of t as text), (URL of t as text)}
+            set oldDelims to AppleScript's text item delimiters
+            set AppleScript's text item delimiters to fieldSep
+            set end of rows to (rowParts as text)
+            set AppleScript's text item delimiters to oldDelims
+        end repeat
+    end repeat
+end tell
+
+set oldDelims to AppleScript's text item delimiters
+set AppleScript's text item delimiters to recordSep
+set outputText to rows as text
+set AppleScript's text item delimiters to oldDelims
+return outputText
+"#
+}
+
+fn chrome_focus_tab_script(window_id: &str, tab_index: u32) -> String {
+    format!(
+        r#"
+tell application "System Events"
+    if not (exists process "Google Chrome") then
+        error "Google Chrome is not running"
+    end if
+end tell
+
+tell application "Google Chrome"
+    set targetWindow to first window whose id is "{}"
+    set index of targetWindow to 1
+    set active tab index of targetWindow to {}
+    activate
+end tell
+"#,
+        apple_script_string(window_id),
+        tab_index
+    )
+}
+
+fn apple_script_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn parse_chrome_tabs_output(output: &str) -> Result<Vec<BrowserTab>, String> {
+    let trimmed_output = output.trim();
+    if trimmed_output.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    trimmed_output
+        .split(APPLE_SCRIPT_RECORD_SEPARATOR)
+        .filter(|line| !line.trim().is_empty())
+        .map(parse_chrome_tab_row)
+        .collect()
+}
+
+fn parse_chrome_tab_row(row: &str) -> Result<BrowserTab, String> {
+    let parts = row
+        .split(APPLE_SCRIPT_FIELD_SEPARATOR)
+        .map(str::trim)
+        .collect::<Vec<_>>();
+
+    if parts.len() != 6 {
+        return Err(format!("invalid Chrome tab row: {row}"));
+    }
+
+    Ok(BrowserTab {
+        browser: "chrome".into(),
+        window_id: parts[0].to_string(),
+        window_index: parts[1]
+            .parse()
+            .map_err(|error| format!("invalid Chrome window index '{}': {error}", parts[1]))?,
+        active_tab_index: parts[2]
+            .parse()
+            .map_err(|error| format!("invalid Chrome active tab index '{}': {error}", parts[2]))?,
+        tab_index: parts[3]
+            .parse()
+            .map_err(|error| format!("invalid Chrome tab index '{}': {error}", parts[3]))?,
+        title: parts[4].to_string(),
+        url: parts[5].to_string(),
+    })
+}
+
+fn filter_browser_tabs(tabs: &[BrowserTab], query: &str) -> Vec<BrowserTab> {
+    let normalized_query = query.trim().to_lowercase();
+    let mut matches = tabs
+        .iter()
+        .filter_map(|tab| {
+            let score = browser_tab_match_score(tab, &normalized_query)?;
+            Some((score, tab.clone()))
+        })
+        .collect::<Vec<_>>();
+
+    matches.sort_by(|left, right| {
+        left.0
+            .cmp(&right.0)
+            .then_with(|| left.1.window_index.cmp(&right.1.window_index))
+            .then_with(|| left.1.tab_index.cmp(&right.1.tab_index))
+    });
+
+    matches.into_iter().map(|(_, tab)| tab).collect()
+}
+
+fn browser_tab_match_score(tab: &BrowserTab, query: &str) -> Option<(u8, u8, usize, usize)> {
+    let title = tab.title.to_lowercase();
+    let url = tab.url.to_lowercase();
+
+    if tab.is_active() && (title.contains(query) || url.contains(query)) {
+        return Some((0, 0, tab.window_index as usize, tab.tab_index as usize));
+    }
+    if title.starts_with(query) {
+        return Some((0, 1, tab.window_index as usize, tab.tab_index as usize));
+    }
+    if title.contains(query) {
+        return Some((0, 2, tab.window_index as usize, tab.tab_index as usize));
+    }
+    if url.starts_with(query) {
+        return Some((1, 0, tab.window_index as usize, tab.tab_index as usize));
+    }
+    if url.contains(query) {
+        return Some((1, 1, tab.window_index as usize, tab.tab_index as usize));
+    }
+
+    None
 }
 
 fn app_path_rank(path: &str) -> usize {

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -70,10 +70,6 @@ impl MacOsAppManager {
 
     pub fn search_browser_tabs(&self, query: &str) -> Result<Vec<BrowserTab>, String> {
         let trimmed_query = query.trim();
-        if trimmed_query.is_empty() {
-            return Ok(Vec::new());
-        }
-
         let output = Command::new("/usr/bin/osascript")
             .arg("-e")
             .arg(chrome_tabs_list_script())
@@ -371,6 +367,18 @@ fn parse_chrome_tab_row(row: &str) -> Result<BrowserTab, String> {
 
 fn filter_browser_tabs(tabs: &[BrowserTab], query: &str) -> Vec<BrowserTab> {
     let normalized_query = query.trim().to_lowercase();
+    if normalized_query.is_empty() {
+        let mut all_tabs = tabs.to_vec();
+        all_tabs.sort_by(|left, right| {
+            right
+                .is_active()
+                .cmp(&left.is_active())
+                .then_with(|| left.window_index.cmp(&right.window_index))
+                .then_with(|| left.tab_index.cmp(&right.tab_index))
+        });
+        return all_tabs;
+    }
+
     let mut matches = tabs
         .iter()
         .filter_map(|tab| {
@@ -761,5 +769,35 @@ mod tests {
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].matched_ports, vec![8080]);
         assert_eq!(matches[1].matched_ports, vec![8080]);
+    }
+
+    #[test]
+    fn empty_browser_tab_query_returns_all_tabs_with_active_first() {
+        let tabs = vec![
+            BrowserTab {
+                browser: "chrome".into(),
+                window_id: "window-1".into(),
+                window_index: 1,
+                active_tab_index: 2,
+                tab_index: 1,
+                title: "First".into(),
+                url: "https://example.com/1".into(),
+            },
+            BrowserTab {
+                browser: "chrome".into(),
+                window_id: "window-1".into(),
+                window_index: 1,
+                active_tab_index: 2,
+                tab_index: 2,
+                title: "Second".into(),
+                url: "https://example.com/2".into(),
+            },
+        ];
+
+        let matches = filter_browser_tabs(&tabs, "");
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].title, "Second");
+        assert_eq!(matches[1].title, "First");
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -238,6 +238,73 @@ pub enum SearchResultKind {
     Command,
     Application,
     Bookmark,
+    BrowserTab,
+}
+
+pub const BROWSER_TAB_COMMAND_PREFIX: &str = "browser-tab";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserTab {
+    pub browser: String,
+    pub window_id: String,
+    pub window_index: u32,
+    pub active_tab_index: u32,
+    pub tab_index: u32,
+    pub title: String,
+    pub url: String,
+}
+
+impl BrowserTab {
+    pub fn command_id(&self) -> CommandId {
+        CommandId::from(format!(
+            "{BROWSER_TAB_COMMAND_PREFIX}:{}:{}:{}",
+            self.browser, self.window_id, self.tab_index
+        ))
+    }
+
+    pub fn subtitle(&self) -> String {
+        format!("{} · {}", self.browser_label(), self.url)
+    }
+
+    pub fn search_text(&self) -> String {
+        format!("{} {} {}", self.title, self.url, self.browser).to_lowercase()
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.window_index == 1 && self.active_tab_index == self.tab_index
+    }
+
+    pub fn browser_label(&self) -> &str {
+        match self.browser.as_str() {
+            "chrome" => "Google Chrome",
+            _ => self.browser.as_str(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserTabTarget {
+    pub browser: String,
+    pub window_id: String,
+    pub tab_index: u32,
+}
+
+pub fn parse_browser_tab_command_id(command_id: &CommandId) -> Option<BrowserTabTarget> {
+    let mut parts = command_id.as_str().split(':');
+    let prefix = parts.next()?;
+    let browser = parts.next()?;
+    let window_id = parts.next()?;
+    let tab_index = parts.next()?.parse::<u32>().ok()?;
+
+    if prefix != BROWSER_TAB_COMMAND_PREFIX || parts.next().is_some() {
+        return None;
+    }
+
+    Some(BrowserTabTarget {
+        browser: browser.to_string(),
+        window_id: window_id.to_string(),
+        tab_index,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- add open Chrome tabs to launcher search results and rank them ahead of indexed results
- focus the selected Chrome tab and bring its window forward when executed
- extend shared launcher/platform types and coverage for the new browser-tab result path

## Testing
- pnpm -C apps/desktop test -- --runInBand
- cargo test -q --manifest-path crates/db/Cargo.toml
- cargo test -q --manifest-path crates/platform/Cargo.toml
- cargo test -q --manifest-path crates/core/Cargo.toml
- cargo test -q --manifest-path crates/features/Cargo.toml
- git push -u origin feat/chrome-tab-search

Closes #15