### PR TITLE
Add clipboard history launcher command

### DIFF
--- a/apps/desktop/src-tauri/src/app/clipboard.rs
+++ b/apps/desktop/src-tauri/src/app/clipboard.rs
@@ -1,0 +1,114 @@
+use objc::rc::autoreleasepool;
+use objc::runtime::Object;
+use objc::{class, msg_send, sel, sel_impl};
+use rayon_features::{ClipboardAccess, ClipboardHistoryService};
+use std::ffi::{c_char, CStr};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+const NSPASTEBOARD_TYPE_STRING: &str = "public.utf8-plain-text";
+const NSUTF8_STRING_ENCODING: usize = 4;
+const CLIPBOARD_POLL_INTERVAL: Duration = Duration::from_millis(750);
+
+#[derive(Clone, Copy, Default)]
+pub struct MacOsClipboardAccess;
+
+impl MacOsClipboardAccess {
+    pub fn change_count(&self) -> Result<i64, String> {
+        autoreleasepool(|| unsafe {
+            let pasteboard = general_pasteboard();
+            let count: i64 = msg_send![pasteboard, changeCount];
+            Ok(count)
+        })
+    }
+}
+
+impl ClipboardAccess for MacOsClipboardAccess {
+    fn read_text(&self) -> Result<Option<String>, String> {
+        autoreleasepool(|| unsafe {
+            let pasteboard = general_pasteboard();
+            let pasteboard_type = nsstring(NSPASTEBOARD_TYPE_STRING);
+            let value: *mut Object = msg_send![pasteboard, stringForType: pasteboard_type];
+            if value.is_null() {
+                return Ok(None);
+            }
+
+            Ok(Some(nsstring_to_string(value)))
+        })
+    }
+
+    fn write_text(&self, text: &str) -> Result<(), String> {
+        autoreleasepool(|| unsafe {
+            let pasteboard = general_pasteboard();
+            let _: i64 = msg_send![pasteboard, clearContents];
+            let value = nsstring(text);
+            let pasteboard_type = nsstring(NSPASTEBOARD_TYPE_STRING);
+            let success: bool = msg_send![pasteboard, setString: value forType: pasteboard_type];
+            if success {
+                Ok(())
+            } else {
+                Err("failed to write text to macOS clipboard".into())
+            }
+        })
+    }
+}
+
+pub fn spawn_clipboard_watcher(
+    clipboard: Arc<ClipboardHistoryService>,
+    access: Arc<MacOsClipboardAccess>,
+) {
+    thread::spawn(move || {
+        let mut last_change_count = access.change_count().ok();
+        if let Err(error) = clipboard.sync_current_clipboard() {
+            eprintln!("failed to capture initial clipboard contents: {error}");
+        }
+
+        loop {
+            thread::sleep(CLIPBOARD_POLL_INTERVAL);
+
+            let change_count = match access.change_count() {
+                Ok(change_count) => change_count,
+                Err(error) => {
+                    eprintln!("failed to poll macOS clipboard: {error}");
+                    continue;
+                }
+            };
+
+            if last_change_count == Some(change_count) {
+                continue;
+            }
+
+            last_change_count = Some(change_count);
+            if let Err(error) = clipboard.sync_current_clipboard() {
+                eprintln!("failed to store clipboard history entry: {error}");
+            }
+        }
+    });
+}
+
+unsafe fn general_pasteboard() -> *mut Object {
+    let cls = class!(NSPasteboard);
+    msg_send![cls, generalPasteboard]
+}
+
+unsafe fn nsstring(value: &str) -> *mut Object {
+    let cls = class!(NSString);
+    let string: *mut Object = msg_send![cls, alloc];
+    let string: *mut Object = msg_send![
+        string,
+        initWithBytes: value.as_ptr()
+        length: value.len()
+        encoding: NSUTF8_STRING_ENCODING
+    ];
+    msg_send![string, autorelease]
+}
+
+unsafe fn nsstring_to_string(value: *mut Object) -> String {
+    let utf8: *const c_char = msg_send![value, UTF8String];
+    if utf8.is_null() {
+        String::new()
+    } else {
+        CStr::from_ptr(utf8).to_string_lossy().into_owned()
+    }
+}

--- a/apps/desktop/src-tauri/src/app/launcher.rs
+++ b/apps/desktop/src-tauri/src/app/launcher.rs
@@ -2,7 +2,9 @@ use super::state::write_launcher;
 use rayon_core::{
     load_config, AppPlatform, CommandRegistry, LauncherService, SearchIndex, APP_REINDEX_COMMAND_ID,
 };
-use rayon_features::{built_in_providers, BuiltInDependencies, ThemeSettingsStore};
+use rayon_features::{
+    built_in_providers, BuiltInDependencies, ClipboardHistoryService, ThemeSettingsStore,
+};
 use rayon_types::{
     BookmarkDefinition, CommandExecutionRequest, CommandExecutionResult, CommandInvocationResult,
 };
@@ -11,9 +13,11 @@ use std::sync::{Arc, RwLock};
 pub fn build_launcher(
     platform: Arc<dyn AppPlatform>,
     search_index: Arc<dyn SearchIndex>,
+    clipboard: Arc<ClipboardHistoryService>,
     theme_settings: Arc<ThemeSettingsStore>,
 ) -> Result<LauncherService, String> {
-    let (registry, bookmarks) = load_registry_and_bookmarks(platform.clone(), theme_settings)?;
+    let (registry, bookmarks) =
+        load_registry_and_bookmarks(platform.clone(), clipboard, theme_settings)?;
     Ok(LauncherService::new(
         registry,
         bookmarks,
@@ -26,9 +30,10 @@ pub fn reload_launcher(
     launcher_slot: &RwLock<LauncherService>,
     platform: Arc<dyn AppPlatform>,
     search_index: Arc<dyn SearchIndex>,
+    clipboard: Arc<ClipboardHistoryService>,
     theme_settings: Arc<ThemeSettingsStore>,
 ) -> Result<CommandExecutionResult, String> {
-    let launcher = build_launcher(platform, search_index, theme_settings)?;
+    let launcher = build_launcher(platform, search_index, clipboard, theme_settings)?;
     let result = launcher
         .execute_command(&CommandExecutionRequest {
             command_id: APP_REINDEX_COMMAND_ID.into(),
@@ -45,12 +50,14 @@ pub fn reload_launcher(
 
 fn load_registry_and_bookmarks(
     platform: Arc<dyn AppPlatform>,
+    clipboard: Arc<ClipboardHistoryService>,
     theme_settings: Arc<ThemeSettingsStore>,
 ) -> Result<(CommandRegistry, Vec<BookmarkDefinition>), String> {
     let mut registry = CommandRegistry::new();
     let loaded_config = load_config().map_err(|error| error.to_string())?;
 
     for provider in built_in_providers(BuiltInDependencies {
+        clipboard,
         platform,
         theme_settings,
     }) {
@@ -91,6 +98,7 @@ fn validate_bookmark_ids(
 mod tests {
     use super::*;
     use rayon_db::SearchIndexStats;
+    use rayon_features::ClipboardAccess;
     use rayon_types::{
         BrowserTab, BrowserTabTarget, CommandId, InstalledApp, ProcessMatch,
         SearchableItemDocument, ThemePreference,
@@ -106,6 +114,18 @@ mod tests {
     }
 
     struct StubPlatform;
+
+    struct StubClipboardAccess;
+
+    impl ClipboardAccess for StubClipboardAccess {
+        fn read_text(&self) -> Result<Option<String>, String> {
+            Ok(None)
+        }
+
+        fn write_text(&self, _text: &str) -> Result<(), String> {
+            Ok(())
+        }
+    }
 
     impl AppPlatform for StubPlatform {
         fn discover_apps(&self) -> Result<Vec<InstalledApp>, String> {
@@ -210,10 +230,18 @@ program = "/bin/echo"
 
         let search_index = Arc::new(StubSearchIndex::default());
         let platform: Arc<dyn AppPlatform> = Arc::new(StubPlatform);
+        let clipboard = Arc::new(
+            ClipboardHistoryService::new(
+                Arc::new(StubClipboardAccess),
+                config_home.join("clipboard-history.json"),
+            )
+            .unwrap(),
+        );
         let theme_settings = Arc::new(ThemeSettingsStore::new(config_home.join("theme.json")));
         let launcher = build_launcher(
             platform.clone(),
             search_index.clone(),
+            clipboard.clone(),
             theme_settings.clone(),
         )
         .unwrap();
@@ -254,8 +282,14 @@ keywords = ["jira", "board"]
             ],
         );
 
-        let result =
-            reload_launcher(&launcher_slot, platform, search_index, theme_settings).unwrap();
+        let result = reload_launcher(
+            &launcher_slot,
+            platform,
+            search_index,
+            clipboard,
+            theme_settings,
+        )
+        .unwrap();
         assert!(result.output.starts_with("reindexed "));
 
         let launcher = launcher_slot.read().unwrap();
@@ -296,10 +330,18 @@ keywords = ["docs"]
 
         let search_index = Arc::new(StubSearchIndex::default());
         let platform: Arc<dyn AppPlatform> = Arc::new(StubPlatform);
+        let clipboard = Arc::new(
+            ClipboardHistoryService::new(
+                Arc::new(StubClipboardAccess),
+                config_home.join("clipboard-history.json"),
+            )
+            .unwrap(),
+        );
         let theme_settings = Arc::new(ThemeSettingsStore::new(config_home.join("theme.json")));
         let launcher = build_launcher(
             platform.clone(),
             search_index.clone(),
+            clipboard.clone(),
             theme_settings.clone(),
         )
         .unwrap();
@@ -320,8 +362,14 @@ url = "not-a-url"
             )],
         );
 
-        let error =
-            reload_launcher(&launcher_slot, platform, search_index, theme_settings).unwrap_err();
+        let error = reload_launcher(
+            &launcher_slot,
+            platform,
+            search_index,
+            clipboard,
+            theme_settings,
+        )
+        .unwrap_err();
         assert!(error.contains("invalid bookmark url"));
 
         let launcher = launcher_slot.read().unwrap();
@@ -338,11 +386,18 @@ url = "not-a-url"
     fn build_launcher_registers_theme_command() {
         let search_index = Arc::new(StubSearchIndex::default());
         let platform: Arc<dyn AppPlatform> = Arc::new(StubPlatform);
+        let clipboard = Arc::new(
+            ClipboardHistoryService::new(
+                Arc::new(StubClipboardAccess),
+                std::env::temp_dir().join("rayon-theme-command-clipboard.json"),
+            )
+            .unwrap(),
+        );
         let theme_settings = Arc::new(ThemeSettingsStore::new(
             std::env::temp_dir().join("rayon-theme-command.json"),
         ));
 
-        let launcher = build_launcher(platform, search_index, theme_settings).unwrap();
+        let launcher = build_launcher(platform, search_index, clipboard, theme_settings).unwrap();
         let results = launcher.search("theme");
 
         assert!(results

--- a/apps/desktop/src-tauri/src/app/mod.rs
+++ b/apps/desktop/src-tauri/src/app/mod.rs
@@ -1,3 +1,4 @@
+mod clipboard;
 mod launcher;
 mod paths;
 mod state;

--- a/apps/desktop/src-tauri/src/app/paths.rs
+++ b/apps/desktop/src-tauri/src/app/paths.rs
@@ -13,3 +13,10 @@ pub fn app_theme_settings_path(app: &AppHandle) -> Result<std::path::PathBuf, St
         .map(|path| path.join("settings").join("theme.json"))
         .map_err(|error| error.to_string())
 }
+
+pub fn app_clipboard_history_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    app.path()
+        .app_local_data_dir()
+        .map(|path| path.join("settings").join("clipboard-history.json"))
+        .map_err(|error| error.to_string())
+}

--- a/apps/desktop/src-tauri/src/app/state.rs
+++ b/apps/desktop/src-tauri/src/app/state.rs
@@ -1,7 +1,7 @@
-use super::{launcher, paths};
+use super::{clipboard, launcher, paths};
 use rayon_core::{AppPlatform, LauncherService, SearchIndex};
 use rayon_db::TantivySearchIndex;
-use rayon_features::ThemeSettingsStore;
+use rayon_features::{ClipboardHistoryService, ThemeSettingsStore};
 use rayon_platform::MacOsAppManager;
 use rayon_types::{
     BrowserTab, CommandExecutionRequest, CommandExecutionResult, CommandInvocationResult,
@@ -18,6 +18,7 @@ pub struct AppState {
     launcher: RwLock<LauncherService>,
     platform: Arc<dyn AppPlatform>,
     search_index: Arc<dyn SearchIndex>,
+    clipboard_history: Arc<ClipboardHistoryService>,
     theme_settings: Arc<ThemeSettingsStore>,
     browser_tab_search_cache: Mutex<BrowserTabSearchCache>,
 }
@@ -29,16 +30,27 @@ impl AppState {
                 .map_err(|error| error.to_string())?,
         );
         let platform = Arc::new(MacOsAppManager);
+        let clipboard_access = Arc::new(clipboard::MacOsClipboardAccess);
+        let clipboard_history = Arc::new(ClipboardHistoryService::new(
+            clipboard_access.clone(),
+            paths::app_clipboard_history_path(app)?,
+        )?);
         let theme_settings = Arc::new(ThemeSettingsStore::new(paths::app_theme_settings_path(
             app,
         )?));
-        let launcher =
-            launcher::build_launcher(platform.clone(), app_index.clone(), theme_settings.clone())?;
+        let launcher = launcher::build_launcher(
+            platform.clone(),
+            app_index.clone(),
+            clipboard_history.clone(),
+            theme_settings.clone(),
+        )?;
+        clipboard::spawn_clipboard_watcher(clipboard_history.clone(), clipboard_access);
 
         Ok(Self {
             launcher: RwLock::new(launcher),
             platform,
             search_index: app_index,
+            clipboard_history,
             theme_settings,
             browser_tab_search_cache: Mutex::new(BrowserTabSearchCache::new()?),
         })
@@ -49,6 +61,7 @@ impl AppState {
             &self.launcher,
             self.platform.clone(),
             self.search_index.clone(),
+            self.clipboard_history.clone(),
             self.theme_settings.clone(),
         )
     }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -62,6 +62,7 @@ const interactiveSession = (
   title: "Kill Process",
   subtitle: "Search by app, process, or port",
   input_placeholder: "Search process name or port 8080",
+  completion_behavior: "hide_launcher",
   query: "",
   is_loading: false,
   results: [
@@ -125,6 +126,7 @@ describe("App", () => {
     vi.mocked(launcherApi.submitLauncherInteractiveSelection).mockResolvedValue({
       kind: "completed",
       output: "opened",
+      completion_behavior: "hide_launcher",
     });
     vi.mocked(launcherApi.hideLauncher).mockResolvedValue(undefined);
     vi.mocked(launcherApi.hideLauncherAndRestoreFocus).mockResolvedValue(undefined);
@@ -384,6 +386,65 @@ describe("App", () => {
     await waitFor(() => {
       expect(launcherApi.hideLauncher).toHaveBeenCalled();
     });
+  });
+
+  it("restores focus after selecting a clipboard history item", async () => {
+    const session = interactiveSession({
+      command_id: "clipboard",
+      title: "Clipboard History",
+      subtitle: "Search your recent clipboard entries",
+      input_placeholder: "Search clipboard history",
+      completion_behavior: "hide_launcher_and_restore_focus",
+      results: [
+        {
+          id: "1",
+          title: "deploy preview url",
+          subtitle: "https://example.com/preview",
+        },
+      ],
+    });
+
+    vi.mocked(launcherApi.searchLauncher).mockResolvedValue([
+      searchResult({
+        id: "clipboard",
+        title: "Clipboard History",
+        subtitle: "Browse and recopy your recent clipboard items",
+        starts_interactive_session: true,
+      }),
+    ]);
+    vi.mocked(launcherApi.executeLauncherCommand).mockResolvedValue({
+      kind: "started_session",
+      session,
+    });
+    vi.mocked(launcherApi.searchInteractiveSession).mockResolvedValue(session);
+    vi.mocked(launcherApi.submitLauncherInteractiveSelection).mockResolvedValue({
+      kind: "completed",
+      output: "copied clipboard item",
+      completion_behavior: "hide_launcher_and_restore_focus",
+    });
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: "clipboard" } });
+
+    expect(await screen.findByText("Clipboard History")).toBeTruthy();
+    await userEvent.keyboard("{Enter}");
+    expect(await screen.findByText("deploy preview url")).toBeTruthy();
+
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(launcherApi.submitLauncherInteractiveSelection).toHaveBeenCalledWith(
+        "session-1",
+        "",
+        "1",
+      );
+    });
+    await waitFor(() => {
+      expect(launcherApi.hideLauncherAndRestoreFocus).toHaveBeenCalled();
+    });
+    expect(launcherApi.hideLauncher).not.toHaveBeenCalled();
   });
 
   it("executes raw argv commands directly from one line", async () => {

--- a/apps/desktop/src/commandExecution.ts
+++ b/apps/desktop/src/commandExecution.ts
@@ -41,6 +41,7 @@ export type InteractiveSessionState = {
   title: string;
   subtitle: string | null;
   input_placeholder: string;
+  completion_behavior: "hide_launcher" | "hide_launcher_and_restore_focus";
   query: string;
   is_loading: boolean;
   results: InteractiveSessionResult[];
@@ -53,7 +54,11 @@ export type CommandInvocationResult =
 
 export type InteractiveSessionSubmitResult =
   | { kind: "updated_session"; session: InteractiveSessionState }
-  | { kind: "completed"; output: string };
+  | {
+      kind: "completed";
+      output: string;
+      completion_behavior: "hide_launcher" | "hide_launcher_and_restore_focus";
+    };
 
 export type CommandArgumentValue =
   | { type: "string"; value: string }

--- a/apps/desktop/src/features/launcher/copy.ts
+++ b/apps/desktop/src/features/launcher/copy.ts
@@ -1,6 +1,9 @@
 import type { InteractiveSessionState, SearchResult } from "@/commandExecution";
 
 export function getInteractiveResultKind(session: InteractiveSessionState): string {
+  if (session.command_id === "clipboard") {
+    return "Clipboard";
+  }
   if (session.command_id === "kill") {
     return "Process";
   }
@@ -11,6 +14,9 @@ export function getInteractiveResultKind(session: InteractiveSessionState): stri
 }
 
 export function getInteractiveEmptyState(session: InteractiveSessionState): string {
+  if (session.command_id === "clipboard") {
+    return "No clipboard items found.";
+  }
   if (session.command_id === "kill") {
     return "No matching processes.";
   }
@@ -21,6 +27,9 @@ export function getInteractiveEmptyState(session: InteractiveSessionState): stri
 }
 
 export function getInteractiveSubmitHint(session: InteractiveSessionState): string {
+  if (session.command_id === "clipboard") {
+    return "Press Enter to copy the selected item and close Rayon.";
+  }
   if (session.command_id === "kill") {
     return "Press Enter to terminate the selected process.";
   }

--- a/apps/desktop/src/features/launcher/useLauncherController.ts
+++ b/apps/desktop/src/features/launcher/useLauncherController.ts
@@ -309,6 +309,7 @@ export function useLauncherController(): LauncherController {
       title: result.title,
       subtitle: result.subtitle,
       input_placeholder: "Type to filter",
+      completion_behavior: "hide_launcher",
       query: "",
       is_loading: true,
       results: [],
@@ -397,7 +398,11 @@ export function useLauncherController(): LauncherController {
         void refreshThemePreference();
 
         try {
-          await hideLauncher();
+          if (response.completion_behavior === "hide_launcher_and_restore_focus") {
+            await hideLauncherAndRestoreFocus();
+          } else {
+            await hideLauncher();
+          }
           resetLauncher();
         } catch (hideError) {
           setError(hideError instanceof Error ? hideError.message : String(hideError));

--- a/apps/desktop/src/launcherViewState.test.ts
+++ b/apps/desktop/src/launcherViewState.test.ts
@@ -42,6 +42,7 @@ const interactiveSession: InteractiveSessionState = {
   title: "Kill Process",
   subtitle: "Search by app, process, or port",
   input_placeholder: "Search process name or port 8080",
+  completion_behavior: "hide_launcher",
   query: "",
   is_loading: false,
   results: [],

--- a/crates/core/src/launcher/execution.rs
+++ b/crates/core/src/launcher/execution.rs
@@ -52,6 +52,7 @@ impl LauncherService {
                 title: session_owner.metadata.title,
                 subtitle: session_owner.metadata.subtitle,
                 input_placeholder: session_owner.metadata.input_placeholder,
+                completion_behavior: session_owner.metadata.completion_behavior,
             };
 
             write_interactive_sessions(&self.interactive_sessions).insert(
@@ -69,6 +70,7 @@ impl LauncherService {
                     title: metadata.title,
                     subtitle: metadata.subtitle,
                     input_placeholder: metadata.input_placeholder,
+                    completion_behavior: metadata.completion_behavior,
                     query: String::new(),
                     is_loading: true,
                     results: Vec::new(),

--- a/crates/core/src/launcher/sessions.rs
+++ b/crates/core/src/launcher/sessions.rs
@@ -27,6 +27,7 @@ impl LauncherService {
             title: session.metadata.title,
             subtitle: session.metadata.subtitle,
             input_placeholder: session.metadata.input_placeholder,
+            completion_behavior: session.metadata.completion_behavior,
             query: request.query.clone(),
             is_loading: false,
             results,
@@ -55,6 +56,7 @@ impl LauncherService {
                         title: session.metadata.title,
                         subtitle: session.metadata.subtitle,
                         input_placeholder: session.metadata.input_placeholder,
+                        completion_behavior: session.metadata.completion_behavior,
                         query: request.query.clone(),
                         is_loading: false,
                         results: update.results,
@@ -66,6 +68,7 @@ impl LauncherService {
                 write_interactive_sessions(&self.interactive_sessions).remove(&request.session_id);
                 Ok(InteractiveSessionSubmitResult::Completed {
                     output: result.output,
+                    completion_behavior: session.metadata.completion_behavior,
                 })
             }
         }

--- a/crates/core/src/launcher/tests.rs
+++ b/crates/core/src/launcher/tests.rs
@@ -6,8 +6,8 @@ use crate::test_support::{
 use rayon_db::SearchIndexStats;
 use rayon_types::{
     BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandExecutionRequest, CommandId,
-    CommandInvocationResult, InteractiveSessionQueryRequest, InteractiveSessionSubmitRequest,
-    InteractiveSessionSubmitResult, SearchResultKind,
+    CommandInvocationResult, InteractiveSessionCompletionBehavior, InteractiveSessionQueryRequest,
+    InteractiveSessionSubmitRequest, InteractiveSessionSubmitResult, SearchResultKind,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -264,6 +264,10 @@ fn execute_starts_interactive_session_for_kill() {
     };
     assert_eq!(session.command_id, CommandId::from("kill"));
     assert_eq!(session.title, "Kill Process");
+    assert_eq!(
+        session.completion_behavior,
+        InteractiveSessionCompletionBehavior::HideLauncher
+    );
     assert!(session.is_loading);
     assert!(session.results.is_empty());
 }
@@ -297,6 +301,10 @@ fn interactive_session_search_and_submit_route_to_provider() {
     assert_eq!(searched.query, "8080");
     assert!(!searched.is_loading);
     assert_eq!(searched.results[0].id, "result:8080");
+    assert_eq!(
+        searched.completion_behavior,
+        InteractiveSessionCompletionBehavior::HideLauncher
+    );
 
     let submitted = launcher
         .submit_interactive_session(&InteractiveSessionSubmitRequest {
@@ -364,7 +372,8 @@ fn completed_interactive_submit_removes_active_session() {
     assert_eq!(
         result,
         InteractiveSessionSubmitResult::Completed {
-            output: "opened example/repo#1".into()
+            output: "opened example/repo#1".into(),
+            completion_behavior: InteractiveSessionCompletionBehavior::HideLauncher,
         }
     );
 

--- a/crates/core/src/test_support.rs
+++ b/crates/core/src/test_support.rs
@@ -8,8 +8,8 @@ use rayon_db::SearchIndexStats;
 use rayon_types::{
     BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandArgumentDefinition,
     CommandArgumentType, CommandDefinition, CommandExecutionRequest, CommandExecutionResult,
-    CommandId, CommandInputMode, InstalledApp, InteractiveSessionMetadata,
-    InteractiveSessionResult, ProcessMatch, SearchableItemDocument,
+    CommandId, CommandInputMode, InstalledApp, InteractiveSessionCompletionBehavior,
+    InteractiveSessionMetadata, InteractiveSessionResult, ProcessMatch, SearchableItemDocument,
 };
 use std::sync::{Arc, Mutex};
 
@@ -72,6 +72,7 @@ impl CommandProvider for TestProvider {
             title: "Kill Process".into(),
             subtitle: Some("Terminate a running process".into()),
             input_placeholder: "Search by process name or port".into(),
+            completion_behavior: InteractiveSessionCompletionBehavior::HideLauncher,
         }))
     }
 
@@ -143,6 +144,7 @@ impl CommandProvider for CompletingProvider {
             title: "My Pull Requests".into(),
             subtitle: Some("Open a pull request".into()),
             input_placeholder: "Filter".into(),
+            completion_behavior: InteractiveSessionCompletionBehavior::HideLauncher,
         }))
     }
 

--- a/crates/features/src/clipboard.rs
+++ b/crates/features/src/clipboard.rs
@@ -1,0 +1,517 @@
+use rayon_core::{CommandError, CommandProvider, InteractiveSessionSubmitOutcome};
+use rayon_types::{
+    CommandDefinition, CommandExecutionRequest, CommandExecutionResult, CommandId,
+    CommandInputMode, InteractiveSessionCompletionBehavior, InteractiveSessionMetadata,
+    InteractiveSessionResult,
+};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+const CLIPBOARD_COMMAND_ID: &str = "clipboard";
+const MAX_CLIPBOARD_HISTORY_ENTRIES: usize = 10;
+
+pub trait ClipboardAccess: Send + Sync {
+    fn read_text(&self) -> Result<Option<String>, String>;
+    fn write_text(&self, text: &str) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClipboardHistoryItem {
+    pub id: u64,
+    pub text: String,
+}
+
+pub struct ClipboardHistoryService {
+    access: Arc<dyn ClipboardAccess>,
+    store: ClipboardHistoryStore,
+}
+
+impl ClipboardHistoryService {
+    pub fn new(access: Arc<dyn ClipboardAccess>, path: PathBuf) -> Result<Self, String> {
+        Ok(Self {
+            access,
+            store: ClipboardHistoryStore::new(path, MAX_CLIPBOARD_HISTORY_ENTRIES)?,
+        })
+    }
+
+    pub fn sync_current_clipboard(&self) -> Result<(), String> {
+        if let Some(text) = self.access.read_text()? {
+            self.store.record_text(&text)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn record_text(&self, text: &str) -> Result<(), String> {
+        self.store.record_text(text)
+    }
+
+    pub fn recent_entries(&self) -> Vec<ClipboardHistoryItem> {
+        self.store.entries()
+    }
+
+    pub fn copy_entry(&self, entry_id: u64) -> Result<ClipboardHistoryItem, String> {
+        let entry = self
+            .store
+            .entry(entry_id)
+            .ok_or_else(|| format!("unknown clipboard item: {entry_id}"))?;
+        self.access.write_text(&entry.text)?;
+        self.store.record_text(&entry.text)?;
+        Ok(entry)
+    }
+}
+
+pub struct ClipboardHistoryProvider {
+    clipboard: Arc<ClipboardHistoryService>,
+}
+
+impl ClipboardHistoryProvider {
+    pub fn new(clipboard: Arc<ClipboardHistoryService>) -> Self {
+        Self { clipboard }
+    }
+}
+
+impl CommandProvider for ClipboardHistoryProvider {
+    fn commands(&self) -> Vec<CommandDefinition> {
+        vec![CommandDefinition {
+            id: CommandId::from(CLIPBOARD_COMMAND_ID),
+            title: "Clipboard History".into(),
+            subtitle: Some("Browse and recopy your recent clipboard items".into()),
+            owner_plugin_id: "builtin.clipboard".into(),
+            keywords: vec![
+                "clipboard".into(),
+                "copy".into(),
+                "paste".into(),
+                "history".into(),
+            ],
+            close_launcher_on_success: false,
+            input_mode: CommandInputMode::Structured,
+            arguments: Vec::new(),
+        }]
+    }
+
+    fn execute(
+        &self,
+        request: &CommandExecutionRequest,
+    ) -> Result<CommandExecutionResult, CommandError> {
+        Err(CommandError::UnknownCommand(request.command_id.clone()))
+    }
+
+    fn start_interactive_session(
+        &self,
+        command_id: &CommandId,
+    ) -> Result<Option<InteractiveSessionMetadata>, CommandError> {
+        if command_id.as_str() != CLIPBOARD_COMMAND_ID {
+            return Ok(None);
+        }
+
+        Ok(Some(InteractiveSessionMetadata {
+            session_id: String::new(),
+            command_id: command_id.clone(),
+            title: "Clipboard History".into(),
+            subtitle: Some("Search your 10 most recent clipboard entries".into()),
+            input_placeholder: "Search clipboard history".into(),
+            completion_behavior: InteractiveSessionCompletionBehavior::HideLauncherAndRestoreFocus,
+        }))
+    }
+
+    fn search_interactive_session(
+        &self,
+        session: &InteractiveSessionMetadata,
+        query: &str,
+    ) -> Result<Vec<InteractiveSessionResult>, CommandError> {
+        if session.command_id.as_str() != CLIPBOARD_COMMAND_ID {
+            return Err(CommandError::UnknownCommand(session.command_id.clone()));
+        }
+
+        Ok(filter_entries(&self.clipboard.recent_entries(), query)
+            .into_iter()
+            .map(to_session_result)
+            .collect())
+    }
+
+    fn submit_interactive_session(
+        &self,
+        session: &InteractiveSessionMetadata,
+        _query: &str,
+        item_id: &str,
+    ) -> Result<InteractiveSessionSubmitOutcome, CommandError> {
+        if session.command_id.as_str() != CLIPBOARD_COMMAND_ID {
+            return Err(CommandError::UnknownCommand(session.command_id.clone()));
+        }
+
+        let entry_id = item_id.parse::<u64>().map_err(|_| {
+            CommandError::InvalidArguments(format!("invalid clipboard item id: {item_id}"))
+        })?;
+        self.clipboard
+            .copy_entry(entry_id)
+            .map_err(CommandError::ExecutionFailed)?;
+
+        Ok(InteractiveSessionSubmitOutcome::Completed(
+            CommandExecutionResult {
+                output: "copied clipboard item".into(),
+            },
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct ClipboardHistoryStore {
+    path: PathBuf,
+    max_entries: usize,
+    state: Arc<Mutex<ClipboardHistoryState>>,
+}
+
+impl ClipboardHistoryStore {
+    fn new(path: PathBuf, max_entries: usize) -> Result<Self, String> {
+        let state = load_state(&path, max_entries)?;
+        Ok(Self {
+            path,
+            max_entries,
+            state: Arc::new(Mutex::new(state)),
+        })
+    }
+
+    fn entries(&self) -> Vec<ClipboardHistoryItem> {
+        match self.state.lock() {
+            Ok(state) => state.entries.clone(),
+            Err(poisoned) => poisoned.into_inner().entries.clone(),
+        }
+    }
+
+    fn entry(&self, entry_id: u64) -> Option<ClipboardHistoryItem> {
+        match self.state.lock() {
+            Ok(state) => state
+                .entries
+                .iter()
+                .find(|entry| entry.id == entry_id)
+                .cloned(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .entries
+                .iter()
+                .find(|entry| entry.id == entry_id)
+                .cloned(),
+        }
+    }
+
+    fn record_text(&self, text: &str) -> Result<(), String> {
+        if text.trim().is_empty() {
+            return Ok(());
+        }
+
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "clipboard history lock poisoned".to_string())?;
+
+        if state
+            .entries
+            .first()
+            .is_some_and(|entry| entry.text == text)
+        {
+            return Ok(());
+        }
+
+        let entry = ClipboardHistoryItem {
+            id: state.next_id,
+            text: text.to_string(),
+        };
+        state.next_id += 1;
+        state.entries.insert(0, entry);
+        if state.entries.len() > self.max_entries {
+            state.entries.truncate(self.max_entries);
+        }
+
+        save_state(&self.path, &state)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ClipboardHistoryState {
+    next_id: u64,
+    entries: Vec<ClipboardHistoryItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ClipboardHistoryFile {
+    #[serde(default)]
+    next_id: u64,
+    #[serde(default)]
+    entries: Vec<ClipboardHistoryItem>,
+}
+
+fn load_state(path: &PathBuf, max_entries: usize) -> Result<ClipboardHistoryState, String> {
+    let file = match std::fs::read(path) {
+        Ok(contents) => serde_json::from_slice::<ClipboardHistoryFile>(&contents)
+            .map_err(|error| format!("failed to parse clipboard history: {error}"))?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => ClipboardHistoryFile {
+            next_id: 1,
+            entries: Vec::new(),
+        },
+        Err(error) => return Err(error.to_string()),
+    };
+    let ClipboardHistoryFile { next_id, entries } = file;
+
+    let mut entries = entries
+        .into_iter()
+        .filter(|entry| !entry.text.trim().is_empty())
+        .collect::<Vec<_>>();
+    entries.truncate(max_entries);
+
+    let next_id = entries
+        .iter()
+        .map(|entry| entry.id)
+        .max()
+        .map_or(next_id.max(1), |max_id| max_id.saturating_add(1));
+
+    Ok(ClipboardHistoryState { next_id, entries })
+}
+
+fn save_state(path: &PathBuf, state: &ClipboardHistoryState) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+
+    let contents = serde_json::to_vec_pretty(&ClipboardHistoryFile {
+        next_id: state.next_id,
+        entries: state.entries.clone(),
+    })
+    .map_err(|error| error.to_string())?;
+    std::fs::write(path, contents).map_err(|error| error.to_string())
+}
+
+fn filter_entries(entries: &[ClipboardHistoryItem], query: &str) -> Vec<ClipboardHistoryItem> {
+    let normalized_query = query.trim().to_lowercase();
+    if normalized_query.is_empty() {
+        return entries.to_vec();
+    }
+
+    entries
+        .iter()
+        .filter(|entry| entry.text.to_lowercase().contains(&normalized_query))
+        .cloned()
+        .collect()
+}
+
+fn to_session_result(entry: ClipboardHistoryItem) -> InteractiveSessionResult {
+    let title = summarize_title(&entry.text);
+    let subtitle = summarize_subtitle(&entry.text);
+
+    InteractiveSessionResult {
+        id: entry.id.to_string(),
+        title,
+        subtitle,
+    }
+}
+
+fn summarize_title(text: &str) -> String {
+    text.lines()
+        .find(|line| !line.trim().is_empty())
+        .map(truncate_preview)
+        .unwrap_or_else(|| truncate_preview(text))
+}
+
+fn summarize_subtitle(text: &str) -> Option<String> {
+    let mut lines = text.lines();
+    let first_line = lines.next().unwrap_or_default();
+    let remainder = lines.collect::<Vec<_>>().join(" ");
+
+    if !remainder.trim().is_empty() {
+        return Some(truncate_preview(&remainder));
+    }
+
+    if first_line.chars().count() > 80 {
+        return Some(format!("{} chars", text.chars().count()));
+    }
+
+    None
+}
+
+fn truncate_preview(text: &str) -> String {
+    const MAX_CHARS: usize = 80;
+
+    let normalized = text.trim().replace('\t', " ");
+    let mut chars = normalized.chars();
+    let preview = chars.by_ref().take(MAX_CHARS).collect::<String>();
+    if chars.next().is_some() {
+        format!("{preview}...")
+    } else {
+        preview
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use rayon_core::CommandRegistry;
+    use rayon_types::InteractiveSessionCompletionBehavior;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Default)]
+    struct StubClipboardAccess {
+        text: Mutex<Option<String>>,
+        writes: Mutex<Vec<String>>,
+    }
+
+    impl ClipboardAccess for StubClipboardAccess {
+        fn read_text(&self) -> Result<Option<String>, String> {
+            Ok(self.text.lock().unwrap().clone())
+        }
+
+        fn write_text(&self, text: &str) -> Result<(), String> {
+            self.writes.lock().unwrap().push(text.to_string());
+            *self.text.lock().unwrap() = Some(text.to_string());
+            Ok(())
+        }
+    }
+
+    fn temp_path(test_name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("rayon-clipboard-{test_name}-{unique}.json"))
+    }
+
+    fn service(path: PathBuf) -> (Arc<ClipboardHistoryService>, Arc<StubClipboardAccess>) {
+        let access = Arc::new(StubClipboardAccess::default());
+        let service = Arc::new(ClipboardHistoryService::new(access.clone(), path).unwrap());
+        (service, access)
+    }
+
+    #[test]
+    fn store_defaults_to_empty_when_missing() {
+        let (service, _) = service(temp_path("missing"));
+        assert!(service.recent_entries().is_empty());
+    }
+
+    #[test]
+    fn store_persists_and_reloads_entries() {
+        let path = temp_path("persist");
+        let (service, _) = service(path.clone());
+        service.record_text("first").unwrap();
+        service.record_text("second").unwrap();
+
+        let reloaded =
+            ClipboardHistoryService::new(Arc::new(StubClipboardAccess::default()), path.clone())
+                .unwrap();
+
+        let entries = reloaded.recent_entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].text, "second");
+        assert_eq!(entries[1].text, "first");
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn store_caps_entries_and_skips_empty_values() {
+        let (service, _) = service(temp_path("cap"));
+        service.record_text("   ").unwrap();
+        for index in 0..12 {
+            service.record_text(&format!("item-{index}")).unwrap();
+        }
+
+        let entries = service.recent_entries();
+        assert_eq!(entries.len(), 10);
+        assert_eq!(entries[0].text, "item-11");
+        assert_eq!(entries[9].text, "item-2");
+    }
+
+    #[test]
+    fn store_dedupes_only_consecutive_values() {
+        let (service, _) = service(temp_path("dedupe"));
+        service.record_text("alpha").unwrap();
+        service.record_text("alpha").unwrap();
+        service.record_text("beta").unwrap();
+        service.record_text("alpha").unwrap();
+
+        let entries = service.recent_entries();
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].text, "alpha");
+        assert_eq!(entries[1].text, "beta");
+        assert_eq!(entries[2].text, "alpha");
+    }
+
+    #[test]
+    fn copy_entry_writes_to_clipboard_and_promotes_entry() {
+        let (service, access) = service(temp_path("copy"));
+        service.record_text("first").unwrap();
+        service.record_text("second").unwrap();
+        let first_entry_id = service.recent_entries()[1].id;
+
+        let copied = service.copy_entry(first_entry_id).unwrap();
+
+        assert_eq!(copied.text, "first");
+        assert_eq!(access.writes.lock().unwrap().as_slice(), ["first"]);
+        let entries = service.recent_entries();
+        assert_eq!(entries[0].text, "first");
+        assert_eq!(entries[1].text, "second");
+    }
+
+    #[test]
+    fn provider_registers_and_filters_entries() {
+        let (service, _) = service(temp_path("filter"));
+        service.record_text("Deploy Rayon").unwrap();
+        service.record_text("Clipboard notes").unwrap();
+
+        let provider = ClipboardHistoryProvider::new(service.clone());
+        let mut registry = CommandRegistry::new();
+        registry
+            .register_provider(Arc::new(ClipboardHistoryProvider::new(service.clone())))
+            .unwrap();
+
+        let results = registry.search_results_by_id();
+        assert_eq!(results["clipboard"].title, "Clipboard History");
+
+        let session = provider
+            .start_interactive_session(&CommandId::from("clipboard"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            session.completion_behavior,
+            InteractiveSessionCompletionBehavior::HideLauncherAndRestoreFocus
+        );
+
+        let filtered = provider
+            .search_interactive_session(&session, "clip")
+            .unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].title, "Clipboard notes");
+    }
+
+    #[test]
+    fn provider_search_and_submit_copy_selected_entry() {
+        let (service, access) = service(temp_path("submit"));
+        service.record_text("alpha").unwrap();
+        service.record_text("beta").unwrap();
+        let provider = ClipboardHistoryProvider::new(service.clone());
+        let session = provider
+            .start_interactive_session(&CommandId::from("clipboard"))
+            .unwrap()
+            .unwrap();
+
+        let results = provider
+            .search_interactive_session(&session, "alp")
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "alpha");
+
+        let outcome = provider
+            .submit_interactive_session(&session, "", &results[0].id)
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            InteractiveSessionSubmitOutcome::Completed(CommandExecutionResult {
+                output: "copied clipboard item".into(),
+            })
+        );
+        assert_eq!(access.writes.lock().unwrap().as_slice(), ["alpha"]);
+    }
+}

--- a/crates/features/src/github.rs
+++ b/crates/features/src/github.rs
@@ -1,7 +1,8 @@
 use rayon_core::{AppPlatform, CommandError, CommandProvider, InteractiveSessionSubmitOutcome};
 use rayon_types::{
     CommandDefinition, CommandExecutionRequest, CommandExecutionResult, CommandId,
-    CommandInputMode, InteractiveSessionMetadata, InteractiveSessionResult,
+    CommandInputMode, InteractiveSessionCompletionBehavior, InteractiveSessionMetadata,
+    InteractiveSessionResult,
 };
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -100,6 +101,7 @@ impl CommandProvider for GitHubMyPrsProvider {
             title: "My Pull Requests".into(),
             subtitle: Some("Open one of your authored pull requests".into()),
             input_placeholder: "Filter by title, repository, or number".into(),
+            completion_behavior: InteractiveSessionCompletionBehavior::HideLauncher,
         }))
     }
 
@@ -447,6 +449,7 @@ mod tests {
             title: "My Pull Requests".into(),
             subtitle: Some("Open one of your authored pull requests".into()),
             input_placeholder: "Filter by title, repository, or number".into(),
+            completion_behavior: InteractiveSessionCompletionBehavior::HideLauncher,
         };
 
         let result = provider
@@ -483,6 +486,7 @@ mod tests {
             title: "My Pull Requests".into(),
             subtitle: Some("Open one of your authored pull requests".into()),
             input_placeholder: "Filter by title, repository, or number".into(),
+            completion_behavior: InteractiveSessionCompletionBehavior::HideLauncher,
         };
 
         let error = provider

--- a/crates/features/src/kill.rs
+++ b/crates/features/src/kill.rs
@@ -4,7 +4,8 @@ use rayon_core::{
 };
 use rayon_types::{
     CommandDefinition, CommandExecutionRequest, CommandExecutionResult, CommandId,
-    CommandInputMode, InteractiveSessionMetadata, InteractiveSessionResult,
+    CommandInputMode, InteractiveSessionCompletionBehavior, InteractiveSessionMetadata,
+    InteractiveSessionResult,
 };
 use std::sync::Arc;
 
@@ -60,6 +61,7 @@ impl CommandProvider for KillProvider {
             title: "Kill Process".into(),
             subtitle: Some("Search by app, process, or port".into()),
             input_placeholder: "Search process name or port 8080".into(),
+            completion_behavior: InteractiveSessionCompletionBehavior::HideLauncher,
         }))
     }
 

--- a/crates/features/src/lib.rs
+++ b/crates/features/src/lib.rs
@@ -1,20 +1,24 @@
+mod clipboard;
 mod github;
 mod kill;
 mod maintenance;
 mod theme;
 
+pub use clipboard::{ClipboardAccess, ClipboardHistoryProvider, ClipboardHistoryService};
 use github::GitHubMyPrsProvider;
 use rayon_core::{AppPlatform, CommandProvider};
 use std::sync::Arc;
 pub use theme::{ThemeCommandProvider, ThemeSettingsStore};
 
 pub struct BuiltInDependencies {
+    pub clipboard: Arc<ClipboardHistoryService>,
     pub platform: Arc<dyn AppPlatform>,
     pub theme_settings: Arc<ThemeSettingsStore>,
 }
 
 pub fn built_in_providers(deps: BuiltInDependencies) -> Vec<Arc<dyn CommandProvider>> {
     vec![
+        Arc::new(ClipboardHistoryProvider::new(deps.clipboard)),
         Arc::new(GitHubMyPrsProvider::new(deps.platform.clone())),
         Arc::new(kill::KillProvider::new(deps.platform)),
         Arc::new(maintenance::MaintenanceProvider),
@@ -73,9 +77,28 @@ mod tests {
 
     fn built_ins() -> Vec<Arc<dyn CommandProvider>> {
         built_in_providers(BuiltInDependencies {
+            clipboard: Arc::new(
+                ClipboardHistoryService::new(
+                    Arc::new(StubClipboardAccess),
+                    temp_theme_path("clipboard"),
+                )
+                .unwrap(),
+            ),
             platform: Arc::new(StubPlatform),
             theme_settings: Arc::new(ThemeSettingsStore::new(temp_theme_path("catalog"))),
         })
+    }
+
+    struct StubClipboardAccess;
+
+    impl ClipboardAccess for StubClipboardAccess {
+        fn read_text(&self) -> Result<Option<String>, String> {
+            Ok(None)
+        }
+
+        fn write_text(&self, _text: &str) -> Result<(), String> {
+            Ok(())
+        }
     }
 
     #[test]
@@ -115,5 +138,17 @@ mod tests {
             results["github.my-prs"].id,
             CommandId::from("github.my-prs")
         );
+    }
+
+    #[test]
+    fn built_in_catalog_registers_clipboard_command() {
+        let mut registry = CommandRegistry::new();
+        for provider in built_ins() {
+            registry.register_provider(provider).unwrap();
+        }
+
+        let results = registry.search_results_by_id();
+
+        assert_eq!(results["clipboard"].id, CommandId::from("clipboard"));
     }
 }

--- a/crates/features/src/theme.rs
+++ b/crates/features/src/theme.rs
@@ -3,7 +3,8 @@ use rayon_core::{
 };
 use rayon_types::{
     CommandDefinition, CommandExecutionRequest, CommandExecutionResult, CommandId,
-    CommandInputMode, InteractiveSessionMetadata, InteractiveSessionResult, ThemePreference,
+    CommandInputMode, InteractiveSessionCompletionBehavior, InteractiveSessionMetadata,
+    InteractiveSessionResult, ThemePreference,
 };
 use std::sync::Arc;
 
@@ -60,6 +61,7 @@ impl CommandProvider for ThemeCommandProvider {
             title: "Set Theme".into(),
             subtitle: Some("Choose the launcher appearance".into()),
             input_placeholder: "Filter light, dark, or system".into(),
+            completion_behavior: InteractiveSessionCompletionBehavior::HideLauncher,
         }))
     }
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -158,6 +158,8 @@ pub struct InteractiveSessionMetadata {
     #[serde(default)]
     pub subtitle: Option<String>,
     pub input_placeholder: String,
+    #[serde(default)]
+    pub completion_behavior: InteractiveSessionCompletionBehavior,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -176,6 +178,8 @@ pub struct InteractiveSessionState {
     #[serde(default)]
     pub subtitle: Option<String>,
     pub input_placeholder: String,
+    #[serde(default)]
+    pub completion_behavior: InteractiveSessionCompletionBehavior,
     pub query: String,
     #[serde(default)]
     pub is_loading: bool,
@@ -205,11 +209,24 @@ pub enum CommandInvocationResult {
     StartedSession { session: InteractiveSessionState },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractiveSessionCompletionBehavior {
+    #[default]
+    HideLauncher,
+    HideLauncherAndRestoreFocus,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum InteractiveSessionSubmitResult {
-    UpdatedSession { session: InteractiveSessionState },
-    Completed { output: String },
+    UpdatedSession {
+        session: InteractiveSessionState,
+    },
+    Completed {
+        output: String,
+        completion_behavior: InteractiveSessionCompletionBehavior,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary
- add a built-in clipboard history launcher command backed by persisted macOS clipboard tracking
- support interactive search, arrow navigation, and Enter-to-recopy with focus restoration
- add session completion behavior metadata plus Rust/frontend coverage for the new flow

Closes #5