### PR TITLE
Add fixed-folder image indexing and clipboard copy

### DIFF
--- a/apps/desktop/src-tauri/src/app/adapters.rs
+++ b/apps/desktop/src-tauri/src/app/adapters.rs
@@ -30,6 +30,10 @@ impl AppPlatform for DesktopPlatform {
         self.inner.open_url(url)
     }
 
+    fn copy_image_to_clipboard(&self, image_path: &std::path::Path) -> Result<(), String> {
+        super::clipboard::copy_image_file_to_clipboard(image_path)
+    }
+
     fn search_browser_tabs(&self, query: &str) -> Result<Vec<BrowserTab>, String> {
         self.inner.search_browser_tabs(query)
     }

--- a/apps/desktop/src-tauri/src/app/clipboard.rs
+++ b/apps/desktop/src-tauri/src/app/clipboard.rs
@@ -54,6 +54,32 @@ impl ClipboardAccess for MacOsClipboardAccess {
     }
 }
 
+pub fn copy_image_file_to_clipboard(path: &std::path::Path) -> Result<(), String> {
+    let path = path
+        .to_str()
+        .ok_or_else(|| format!("invalid image path: {}", path.display()))?;
+
+    autoreleasepool(|| unsafe {
+        let image_class = class!(NSImage);
+        let image: *mut Object = msg_send![image_class, alloc];
+        let image: *mut Object = msg_send![image, initWithContentsOfFile: nsstring(path)];
+        if image.is_null() {
+            return Err(format!("failed to load image at {}", path));
+        }
+
+        let array_class = class!(NSArray);
+        let objects: *mut Object = msg_send![array_class, arrayWithObject: image];
+        let pasteboard = general_pasteboard();
+        let _: i64 = msg_send![pasteboard, clearContents];
+        let success: bool = msg_send![pasteboard, writeObjects: objects];
+        if success {
+            Ok(())
+        } else {
+            Err(format!("failed to write image to macOS clipboard: {path}"))
+        }
+    })
+}
+
 pub fn spawn_clipboard_watcher(
     clipboard: Arc<ClipboardHistoryService>,
     access: Arc<MacOsClipboardAccess>,

--- a/apps/desktop/src-tauri/src/app/launcher.rs
+++ b/apps/desktop/src-tauri/src/app/launcher.rs
@@ -7,6 +7,7 @@ use rayon_features::{
 };
 use rayon_types::{
     BookmarkDefinition, CommandExecutionRequest, CommandExecutionResult, CommandInvocationResult,
+    ImageAssetDefinition,
 };
 use std::sync::{Arc, RwLock};
 
@@ -16,11 +17,12 @@ pub fn build_launcher(
     clipboard: Arc<ClipboardHistoryService>,
     theme_settings: Arc<ThemeSettingsStore>,
 ) -> Result<LauncherService, String> {
-    let (registry, bookmarks) =
-        load_registry_and_bookmarks(platform.clone(), clipboard, theme_settings)?;
+    let (registry, bookmarks, images) =
+        load_registry_bookmarks_and_images(platform.clone(), clipboard, theme_settings)?;
     Ok(LauncherService::new(
         registry,
         bookmarks,
+        images,
         platform,
         search_index,
     ))
@@ -48,11 +50,18 @@ pub fn reload_launcher(
     Ok(CommandExecutionResult { output })
 }
 
-fn load_registry_and_bookmarks(
+fn load_registry_bookmarks_and_images(
     platform: Arc<dyn AppPlatform>,
     clipboard: Arc<ClipboardHistoryService>,
     theme_settings: Arc<ThemeSettingsStore>,
-) -> Result<(CommandRegistry, Vec<BookmarkDefinition>), String> {
+) -> Result<
+    (
+        CommandRegistry,
+        Vec<BookmarkDefinition>,
+        Vec<ImageAssetDefinition>,
+    ),
+    String,
+> {
     let mut registry = CommandRegistry::new();
     let loaded_config = load_config().map_err(|error| error.to_string())?;
 
@@ -73,7 +82,11 @@ fn load_registry_and_bookmarks(
     }
 
     validate_bookmark_ids(&registry, &loaded_config.bookmarks)?;
-    Ok((registry, loaded_config.bookmarks))
+    Ok((
+        registry,
+        loaded_config.bookmarks,
+        loaded_config.image_assets,
+    ))
 }
 
 fn validate_bookmark_ids(
@@ -137,6 +150,10 @@ mod tests {
         }
 
         fn open_url(&self, _url: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn copy_image_to_clipboard(&self, _image_path: &std::path::Path) -> Result<(), String> {
             Ok(())
         }
 

--- a/apps/desktop/src-tauri/src/app/state.rs
+++ b/apps/desktop/src-tauri/src/app/state.rs
@@ -281,6 +281,10 @@ mod tests {
             Ok(())
         }
 
+        fn copy_image_to_clipboard(&self, _image_path: &std::path::Path) -> Result<(), String> {
+            Ok(())
+        }
+
         fn search_browser_tabs(&self, _query: &str) -> Result<Vec<BrowserTab>, String> {
             *self.search_calls.lock().unwrap() += 1;
             Ok(self.browser_tabs.lock().unwrap().clone())

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -216,6 +216,26 @@ describe("App", () => {
     expect(input.getAttribute("data-mode")).toBe("browser_tabs");
   });
 
+  it("renders image results with the image badge", async () => {
+    vi.mocked(launcherApi.searchLauncher).mockResolvedValue([
+      searchResult({
+        id: "image-asset:assets/logos/brand.png",
+        title: "brand.png",
+        subtitle: "assets/logos/brand.png",
+        kind: "image",
+        close_launcher_on_success: true,
+      }),
+    ]);
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: "brand" } });
+
+    expect(await screen.findByText("brand.png")).toBeTruthy();
+    expect(await screen.findByText("Image")).toBeTruthy();
+  });
+
   it("shows all tabs when the query is only a leading space", async () => {
     vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
       searchResult({

--- a/apps/desktop/src/commandExecution.ts
+++ b/apps/desktop/src/commandExecution.ts
@@ -16,7 +16,7 @@ export type SearchResult = {
   title: string;
   subtitle: string | null;
   icon_path: string | null;
-  kind: "command" | "application" | "bookmark" | "browser_tab";
+  kind: "command" | "application" | "bookmark" | "image" | "browser_tab";
   owner_plugin_id: string | null;
   keywords: string[];
   starts_interactive_session: boolean;

--- a/apps/desktop/src/features/launcher/copy.ts
+++ b/apps/desktop/src/features/launcher/copy.ts
@@ -43,6 +43,9 @@ export function getSearchResultKind(result: SearchResult): string {
   if (result.kind === "browser_tab") {
     return "Tab";
   }
+  if (result.kind === "image") {
+    return "Image";
+  }
   if (result.kind === "application") {
     return "App";
   }

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -1,13 +1,16 @@
 use rayon_types::{
-    BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandId, CommandInputMode, InstalledApp,
-    ProcessMatch, SearchIndexStats, SearchResult, SearchResultKind, SearchableItemDocument,
+    BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandId, CommandInputMode,
+    ImageAssetDefinition, InstalledApp, ProcessMatch, SearchIndexStats, SearchResult,
+    SearchResultKind, SearchableItemDocument,
 };
 use std::collections::HashMap;
+use std::path::Path;
 
 pub trait AppPlatform: Send + Sync {
     fn discover_apps(&self) -> Result<Vec<InstalledApp>, String>;
     fn launch_app(&self, app: &InstalledApp) -> Result<(), String>;
     fn open_url(&self, url: &str) -> Result<(), String>;
+    fn copy_image_to_clipboard(&self, image_path: &Path) -> Result<(), String>;
     fn search_browser_tabs(&self, query: &str) -> Result<Vec<BrowserTab>, String>;
     fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String>;
     fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String>;
@@ -148,4 +151,67 @@ fn bookmark_search_text(definition: &BookmarkDefinition) -> String {
     }
     parts.extend(definition.keywords.clone());
     parts.join(" ")
+}
+
+#[derive(Default)]
+pub(crate) struct ImageCatalog {
+    by_id: HashMap<String, ImageAssetDefinition>,
+}
+
+impl ImageCatalog {
+    pub(crate) fn from_images(images: Vec<ImageAssetDefinition>) -> Self {
+        let mut by_id = HashMap::new();
+        for image in images {
+            by_id.insert(image.id.to_string(), image);
+        }
+
+        Self { by_id }
+    }
+
+    pub(crate) fn get(&self, image_id: &CommandId) -> Option<&ImageAssetDefinition> {
+        self.by_id.get(image_id.as_str())
+    }
+
+    pub(crate) fn search_results_by_id(&self) -> HashMap<String, SearchResult> {
+        self.by_id
+            .values()
+            .map(|image| {
+                (
+                    image.id.to_string(),
+                    SearchResult {
+                        id: image.id.clone(),
+                        title: image.title.clone(),
+                        subtitle: Some(image.relative_path.clone()),
+                        icon_path: None,
+                        kind: SearchResultKind::Image,
+                        owner_plugin_id: None,
+                        keywords: Vec::new(),
+                        starts_interactive_session: false,
+                        close_launcher_on_success: true,
+                        input_mode: CommandInputMode::Structured,
+                        arguments: Vec::new(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn searchable_documents(&self) -> Vec<SearchableItemDocument> {
+        self.by_id
+            .values()
+            .map(|image| SearchableItemDocument {
+                id: image.id.clone(),
+                kind: SearchResultKind::Image,
+                title: image.title.clone(),
+                subtitle: Some(image.relative_path.clone()),
+                owner_plugin_id: None,
+                search_text: image_search_text(image),
+            })
+            .collect()
+    }
+}
+
+fn image_search_text(image: &ImageAssetDefinition) -> String {
+    let path_tokens = image.relative_path.replace(['/', '\\'], " ");
+    format!("{} {} {}", image.title, image.relative_path, path_tokens)
 }

--- a/crates/core/src/config/images.rs
+++ b/crates/core/src/config/images.rs
@@ -1,0 +1,72 @@
+use rayon_types::{CommandId, ImageAssetDefinition};
+use std::fs;
+use std::path::Path;
+
+const IMAGE_ASSET_COMMAND_PREFIX: &str = "image-asset:";
+const SUPPORTED_IMAGE_EXTENSIONS: &[&str] =
+    &["png", "jpg", "jpeg", "gif", "webp", "bmp", "tif", "tiff"];
+
+pub(super) fn load_images(config_dir: &Path) -> Result<Vec<ImageAssetDefinition>, String> {
+    let image_root = config_dir.join("images");
+    if !image_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut images = Vec::new();
+    collect_images(&image_root, &image_root, &mut images)?;
+    images.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(images)
+}
+
+fn collect_images(
+    image_root: &Path,
+    current_dir: &Path,
+    images: &mut Vec<ImageAssetDefinition>,
+) -> Result<(), String> {
+    let entries = fs::read_dir(current_dir).map_err(|error| {
+        format!(
+            "failed to read image assets directory {}: {error}",
+            current_dir.display()
+        )
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_images(image_root, &path, images)?;
+            continue;
+        }
+
+        if !is_supported_image(&path) {
+            continue;
+        }
+
+        let relative_path = path
+            .strip_prefix(image_root)
+            .map_err(|error| error.to_string())?
+            .to_string_lossy()
+            .replace('\\', "/");
+        let title = path
+            .file_name()
+            .and_then(|file_name| file_name.to_str())
+            .ok_or_else(|| format!("invalid image asset filename: {}", path.display()))?
+            .to_string();
+
+        images.push(ImageAssetDefinition {
+            id: CommandId::from(format!("{IMAGE_ASSET_COMMAND_PREFIX}{relative_path}")),
+            title,
+            relative_path,
+            path: path.to_string_lossy().into_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+fn is_supported_image(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .is_some_and(|extension| SUPPORTED_IMAGE_EXTENSIONS.contains(&extension.as_str()))
+}

--- a/crates/core/src/config/loader.rs
+++ b/crates/core/src/config/loader.rs
@@ -3,7 +3,7 @@ use super::manifest::PluginManifest;
 use crate::declarative_provider::{DeclarativeCommandProvider, ExecutableCommandSpec};
 use crate::CommandProvider;
 use rayon_types::CommandInputMode;
-use rayon_types::{BookmarkDefinition, CommandDefinition, CommandId};
+use rayon_types::{BookmarkDefinition, CommandDefinition, CommandId, ImageAssetDefinition};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -11,6 +11,7 @@ use std::sync::Arc;
 pub struct LoadedConfig {
     pub command_providers: Vec<Arc<dyn CommandProvider>>,
     pub bookmarks: Vec<BookmarkDefinition>,
+    pub image_assets: Vec<ImageAssetDefinition>,
 }
 
 pub(super) struct LoadedManifestBundle {

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -1,5 +1,6 @@
 mod bookmarks;
 mod discovery;
+mod images;
 mod loader;
 pub(crate) mod manifest;
 
@@ -18,11 +19,13 @@ pub fn load_config() -> Result<LoadedConfig, String> {
         return Ok(LoadedConfig {
             command_providers: Vec::new(),
             bookmarks: Vec::new(),
+            image_assets: Vec::new(),
         });
     }
 
     let mut command_providers: Vec<Arc<dyn CommandProvider>> = Vec::new();
     let mut bookmarks = Vec::new();
+    let image_assets = images::load_images(&config_dir)?;
     let mut bookmark_ids = HashSet::new();
 
     for manifest_path in discovery::manifest_paths(&config_dir)? {
@@ -44,5 +47,6 @@ pub fn load_config() -> Result<LoadedConfig, String> {
     Ok(LoadedConfig {
         command_providers,
         bookmarks,
+        image_assets,
     })
 }

--- a/crates/core/src/config/tests.rs
+++ b/crates/core/src/config/tests.rs
@@ -201,3 +201,55 @@ close_launcher_on_success = true
     assert_eq!(commands.len(), 1);
     assert!(commands[0].close_launcher_on_success);
 }
+
+#[allow(clippy::unwrap_used)]
+#[test]
+fn loads_nested_images_from_fixed_images_directory() {
+    let _env_guard = env_lock().lock().unwrap();
+    let config_home = unique_dir();
+    let rayon_dir = config_home.join("rayon");
+    let image_dir = rayon_dir.join("images").join("assets").join("logos");
+    fs::create_dir_all(&image_dir).unwrap();
+    fs::write(image_dir.join("brand.png"), b"png").unwrap();
+    fs::write(image_dir.join("ignore.txt"), b"text").unwrap();
+
+    let previous = env::var_os("XDG_CONFIG_HOME");
+    env::set_var("XDG_CONFIG_HOME", &config_home);
+    let loaded = load_config().unwrap();
+    if let Some(previous) = previous {
+        env::set_var("XDG_CONFIG_HOME", previous);
+    } else {
+        env::remove_var("XDG_CONFIG_HOME");
+    }
+
+    assert_eq!(loaded.image_assets.len(), 1);
+    assert_eq!(loaded.image_assets[0].title, "brand.png");
+    assert_eq!(
+        loaded.image_assets[0].relative_path,
+        "assets/logos/brand.png"
+    );
+    assert_eq!(
+        loaded.image_assets[0].id,
+        rayon_types::CommandId::from("image-asset:assets/logos/brand.png")
+    );
+}
+
+#[allow(clippy::unwrap_used)]
+#[test]
+fn missing_images_directory_is_allowed() {
+    let _env_guard = env_lock().lock().unwrap();
+    let config_home = unique_dir();
+    let rayon_dir = config_home.join("rayon");
+    fs::create_dir_all(&rayon_dir).unwrap();
+
+    let previous = env::var_os("XDG_CONFIG_HOME");
+    env::set_var("XDG_CONFIG_HOME", &config_home);
+    let loaded = load_config().unwrap();
+    if let Some(previous) = previous {
+        env::set_var("XDG_CONFIG_HOME", previous);
+    } else {
+        env::remove_var("XDG_CONFIG_HOME");
+    }
+
+    assert!(loaded.image_assets.is_empty());
+}

--- a/crates/core/src/launcher/execution.rs
+++ b/crates/core/src/launcher/execution.rs
@@ -16,6 +16,7 @@ impl LauncherService {
         match resolve_execution_target(
             &request.command_id,
             self.bookmark_catalog.get(&request.command_id).is_some(),
+            self.image_catalog.get(&request.command_id).is_some(),
         ) {
             ExecutionTarget::Reindex => {
                 let result = self.refresh_and_reindex()?;
@@ -37,6 +38,12 @@ impl LauncherService {
             }
             ExecutionTarget::Bookmark(bookmark_id) => {
                 let result = self.open_bookmark(&bookmark_id)?;
+                Ok(CommandInvocationResult::Completed {
+                    output: result.output,
+                })
+            }
+            ExecutionTarget::Image(image_id) => {
+                let result = self.copy_image(&image_id)?;
                 Ok(CommandInvocationResult::Completed {
                     output: result.output,
                 })
@@ -125,6 +132,22 @@ impl LauncherService {
 
         Ok(CommandExecutionResult {
             output: "focused Chrome tab".into(),
+        })
+    }
+
+    fn copy_image(&self, image_id: &CommandId) -> Result<CommandExecutionResult, LauncherError> {
+        let image = self
+            .image_catalog
+            .get(image_id)
+            .cloned()
+            .ok_or_else(|| LauncherError::AppNotFound(image_id.clone()))?;
+
+        self.platform
+            .copy_image_to_clipboard(std::path::Path::new(&image.path))
+            .map_err(LauncherError::Platform)?;
+
+        Ok(CommandExecutionResult {
+            output: format!("copied {}", image.title),
         })
     }
 

--- a/crates/core/src/launcher/routing.rs
+++ b/crates/core/src/launcher/routing.rs
@@ -6,12 +6,14 @@ pub(super) enum ExecutionTarget {
     App(CommandId),
     BrowserTab(BrowserTabTarget),
     Bookmark(CommandId),
+    Image(CommandId),
     Provider(CommandId),
 }
 
 pub(super) fn resolve_execution_target(
     command_id: &CommandId,
     bookmark_exists: bool,
+    image_exists: bool,
 ) -> ExecutionTarget {
     if command_id.as_str() == APP_REINDEX_COMMAND_ID {
         return ExecutionTarget::Reindex;
@@ -27,6 +29,10 @@ pub(super) fn resolve_execution_target(
 
     if bookmark_exists {
         return ExecutionTarget::Bookmark(command_id.clone());
+    }
+
+    if image_exists {
+        return ExecutionTarget::Image(command_id.clone());
     }
 
     ExecutionTarget::Provider(command_id.clone())

--- a/crates/core/src/launcher/search.rs
+++ b/crates/core/src/launcher/search.rs
@@ -19,6 +19,7 @@ impl LauncherService {
         let app_results = read_app_catalog(&self.app_catalog).search_results_by_id();
         search_results.extend(app_results);
         search_results.extend(self.bookmark_catalog.search_results_by_id());
+        search_results.extend(self.image_catalog.search_results_by_id());
 
         let mut results = Vec::new();
         for item_id in item_ids {
@@ -39,6 +40,7 @@ impl LauncherService {
         let app_documents = read_app_catalog(&self.app_catalog).searchable_documents();
         documents.extend(app_documents);
         documents.extend(self.bookmark_catalog.searchable_documents());
+        documents.extend(self.image_catalog.searchable_documents());
         self.search_index.replace_items(&documents)
     }
 }

--- a/crates/core/src/launcher/service.rs
+++ b/crates/core/src/launcher/service.rs
@@ -1,7 +1,7 @@
 use super::state::ActiveInteractiveSession;
-use crate::catalog::{AppCatalog, AppPlatform, BookmarkCatalog, SearchIndex};
+use crate::catalog::{AppCatalog, AppPlatform, BookmarkCatalog, ImageCatalog, SearchIndex};
 use crate::commands::CommandRegistry;
-use rayon_types::BookmarkDefinition;
+use rayon_types::{BookmarkDefinition, ImageAssetDefinition};
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
@@ -12,6 +12,7 @@ pub struct LauncherService {
     pub(super) search_index: Arc<dyn SearchIndex>,
     pub(super) app_catalog: RwLock<AppCatalog>,
     pub(super) bookmark_catalog: BookmarkCatalog,
+    pub(super) image_catalog: ImageCatalog,
     pub(super) interactive_sessions: RwLock<HashMap<String, ActiveInteractiveSession>>,
     pub(super) next_session_id: AtomicU64,
 }
@@ -20,6 +21,7 @@ impl LauncherService {
     pub fn new(
         registry: CommandRegistry,
         bookmarks: Vec<BookmarkDefinition>,
+        images: Vec<ImageAssetDefinition>,
         platform: Arc<dyn AppPlatform>,
         search_index: Arc<dyn SearchIndex>,
     ) -> Self {
@@ -37,6 +39,7 @@ impl LauncherService {
             search_index,
             app_catalog: RwLock::new(app_catalog),
             bookmark_catalog: BookmarkCatalog::from_bookmarks(bookmarks),
+            image_catalog: ImageCatalog::from_images(images),
             interactive_sessions: RwLock::new(HashMap::new()),
             next_session_id: AtomicU64::new(1),
         };

--- a/crates/core/src/launcher/tests.rs
+++ b/crates/core/src/launcher/tests.rs
@@ -7,9 +7,10 @@ use crate::SearchIndexStats;
 use crate::{CommandError, CommandProvider, InteractiveSessionSubmitOutcome};
 use rayon_types::{
     BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandDefinition, CommandExecutionRequest,
-    CommandId, CommandInputMode, CommandInvocationResult, InteractiveSessionCompletionBehavior,
-    InteractiveSessionMetadata, InteractiveSessionQueryRequest, InteractiveSessionResult,
-    InteractiveSessionSubmitRequest, InteractiveSessionSubmitResult, SearchResultKind,
+    CommandId, CommandInputMode, CommandInvocationResult, ImageAssetDefinition,
+    InteractiveSessionCompletionBehavior, InteractiveSessionMetadata,
+    InteractiveSessionQueryRequest, InteractiveSessionResult, InteractiveSessionSubmitRequest,
+    InteractiveSessionSubmitResult, SearchResultKind,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -43,6 +44,7 @@ fn launcher_with_platform(
             url: "https://github.com".into(),
             keywords: vec!["code".into()],
         }],
+        Vec::new(),
         platform,
         index,
     )
@@ -77,6 +79,7 @@ fn aggregate_search_does_not_include_browser_tabs() {
         }],
         launched: Mutex::new(Vec::new()),
         opened_urls: Mutex::new(Vec::new()),
+        copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(vec![BrowserTab {
             browser: "chrome".into(),
             window_id: "window-1".into(),
@@ -168,6 +171,7 @@ fn execute_routes_browser_tab_ids_to_platform_focus() {
         apps: Vec::new(),
         launched: Mutex::new(Vec::new()),
         opened_urls: Mutex::new(Vec::new()),
+        copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(vec![BrowserTab {
             browser: "chrome".into(),
             window_id: "window-1".into(),
@@ -300,6 +304,7 @@ fn completed_interactive_submit_removes_active_session() {
         apps: Vec::new(),
         launched: Mutex::new(Vec::new()),
         opened_urls: Mutex::new(Vec::new()),
+        copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
@@ -315,7 +320,7 @@ fn completed_interactive_submit_removes_active_session() {
         },
         last_documents: Mutex::new(Vec::new()),
     });
-    let launcher = LauncherService::new(registry, Vec::new(), platform, index);
+    let launcher = LauncherService::new(registry, Vec::new(), Vec::new(), platform, index);
 
     let session_result = launcher
         .execute_command(&CommandExecutionRequest {
@@ -444,6 +449,7 @@ fn completed_interactive_submit_calls_provider_cleanup() {
         apps: Vec::new(),
         launched: Mutex::new(Vec::new()),
         opened_urls: Mutex::new(Vec::new()),
+        copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
@@ -459,7 +465,7 @@ fn completed_interactive_submit_calls_provider_cleanup() {
         },
         last_documents: Mutex::new(Vec::new()),
     });
-    let launcher = LauncherService::new(registry, Vec::new(), platform, index);
+    let launcher = LauncherService::new(registry, Vec::new(), Vec::new(), platform, index);
 
     let session = match launcher
         .execute_command(&CommandExecutionRequest {
@@ -499,6 +505,7 @@ fn startup_reindexes_commands_and_apps() {
         }],
         launched: Mutex::new(Vec::new()),
         opened_urls: Mutex::new(Vec::new()),
+        copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
@@ -525,6 +532,7 @@ fn startup_reindexes_commands_and_apps() {
             url: "https://github.com".into(),
             keywords: vec!["git".into()],
         }],
+        Vec::new(),
         platform,
         index.clone(),
     );
@@ -557,4 +565,100 @@ fn command_search_results_include_close_launcher_flag() {
         .unwrap();
 
     assert!(!command.close_launcher_on_success);
+}
+
+#[allow(clippy::unwrap_used)]
+#[test]
+fn aggregate_search_includes_images() {
+    let platform = Arc::new(StubPlatform {
+        apps: Vec::new(),
+        launched: Mutex::new(Vec::new()),
+        opened_urls: Mutex::new(Vec::new()),
+        copied_images: Mutex::new(Vec::new()),
+        browser_tabs: Mutex::new(Vec::new()),
+        focused_browser_tabs: Mutex::new(Vec::new()),
+        process_search_results: Mutex::new(Vec::new()),
+        terminated_pids: Mutex::new(Vec::new()),
+    });
+    let launcher = LauncherService::new(
+        CommandRegistry::new(),
+        Vec::new(),
+        vec![ImageAssetDefinition {
+            id: CommandId::from("image-asset:logos/brand.png"),
+            title: "brand.png".into(),
+            relative_path: "logos/brand.png".into(),
+            path: "/tmp/logos/brand.png".into(),
+        }],
+        platform,
+        Arc::new(StubSearchIndex {
+            configured: true,
+            search_results: vec![String::from("image-asset:logos/brand.png")],
+            stats: SearchIndexStats {
+                discovered_count: 0,
+                indexed_count: 1,
+                skipped_count: 0,
+            },
+            last_documents: Mutex::new(Vec::new()),
+        }),
+    );
+
+    let results = launcher.search("brand");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].kind, SearchResultKind::Image);
+    assert!(results[0].close_launcher_on_success);
+}
+
+#[allow(clippy::unwrap_used)]
+#[test]
+fn execute_routes_image_ids_to_clipboard_copy() {
+    let platform = Arc::new(StubPlatform {
+        apps: Vec::new(),
+        launched: Mutex::new(Vec::new()),
+        opened_urls: Mutex::new(Vec::new()),
+        copied_images: Mutex::new(Vec::new()),
+        browser_tabs: Mutex::new(Vec::new()),
+        focused_browser_tabs: Mutex::new(Vec::new()),
+        process_search_results: Mutex::new(Vec::new()),
+        terminated_pids: Mutex::new(Vec::new()),
+    });
+    let launcher = LauncherService::new(
+        CommandRegistry::new(),
+        Vec::new(),
+        vec![ImageAssetDefinition {
+            id: CommandId::from("image-asset:logos/brand.png"),
+            title: "brand.png".into(),
+            relative_path: "logos/brand.png".into(),
+            path: "/tmp/logos/brand.png".into(),
+        }],
+        platform.clone(),
+        Arc::new(StubSearchIndex {
+            configured: true,
+            search_results: Vec::new(),
+            stats: SearchIndexStats {
+                discovered_count: 0,
+                indexed_count: 0,
+                skipped_count: 0,
+            },
+            last_documents: Mutex::new(Vec::new()),
+        }),
+    );
+
+    let result = launcher
+        .execute_command(&CommandExecutionRequest {
+            command_id: CommandId::from("image-asset:logos/brand.png"),
+            argv: Vec::new(),
+            arguments: HashMap::new(),
+        })
+        .unwrap();
+
+    assert_eq!(
+        result,
+        CommandInvocationResult::Completed {
+            output: "copied brand.png".into()
+        }
+    );
+    assert_eq!(
+        &*platform.copied_images.lock().unwrap(),
+        &[String::from("/tmp/logos/brand.png")]
+    );
 }

--- a/crates/core/src/test_support.rs
+++ b/crates/core/src/test_support.rs
@@ -10,6 +10,7 @@ use rayon_types::{
     CommandId, CommandInputMode, InstalledApp, InteractiveSessionCompletionBehavior,
     InteractiveSessionMetadata, InteractiveSessionResult, ProcessMatch, SearchableItemDocument,
 };
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 pub(crate) struct TestProvider;
@@ -177,6 +178,7 @@ pub(crate) struct StubPlatform {
     pub apps: Vec<InstalledApp>,
     pub launched: Mutex<Vec<String>>,
     pub opened_urls: Mutex<Vec<String>>,
+    pub copied_images: Mutex<Vec<String>>,
     pub browser_tabs: Mutex<Vec<BrowserTab>>,
     pub focused_browser_tabs: Mutex<Vec<BrowserTabTarget>>,
     pub process_search_results: Mutex<Vec<ProcessMatch>>,
@@ -195,6 +197,14 @@ impl AppPlatform for StubPlatform {
 
     fn open_url(&self, url: &str) -> Result<(), String> {
         self.opened_urls.lock().unwrap().push(url.to_string());
+        Ok(())
+    }
+
+    fn copy_image_to_clipboard(&self, image_path: &Path) -> Result<(), String> {
+        self.copied_images
+            .lock()
+            .unwrap()
+            .push(image_path.display().to_string());
         Ok(())
     }
 
@@ -266,6 +276,7 @@ pub(crate) fn build_launcher_service(search_results: Vec<String>) -> LauncherSer
         }],
         launched: Mutex::new(Vec::new()),
         opened_urls: Mutex::new(Vec::new()),
+        copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
@@ -292,6 +303,7 @@ pub(crate) fn build_launcher_service(search_results: Vec<String>) -> LauncherSer
             url: "https://github.com".into(),
             keywords: vec!["git".into(), "repos".into()],
         }],
+        Vec::new(),
         platform,
         index,
     )

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -263,6 +263,7 @@ fn search_kind(kind: SearchResultKind) -> &'static str {
         SearchResultKind::Command => "command",
         SearchResultKind::Application => "application",
         SearchResultKind::Bookmark => "bookmark",
+        SearchResultKind::Image => "image",
         SearchResultKind::BrowserTab => "browser_tab",
     }
 }

--- a/crates/features/src/github.rs
+++ b/crates/features/src/github.rs
@@ -337,6 +337,10 @@ mod tests {
             Ok(())
         }
 
+        fn copy_image_to_clipboard(&self, _image_path: &std::path::Path) -> Result<(), String> {
+            Ok(())
+        }
+
         fn search_browser_tabs(&self, _query: &str) -> Result<Vec<BrowserTab>, String> {
             Ok(Vec::new())
         }

--- a/crates/features/src/lib.rs
+++ b/crates/features/src/lib.rs
@@ -50,6 +50,10 @@ mod tests {
             Ok(())
         }
 
+        fn copy_image_to_clipboard(&self, _image_path: &std::path::Path) -> Result<(), String> {
+            Ok(())
+        }
+
         fn search_browser_tabs(&self, _query: &str) -> Result<Vec<BrowserTab>, String> {
             Ok(Vec::new())
         }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -255,7 +255,16 @@ pub enum SearchResultKind {
     Command,
     Application,
     Bookmark,
+    Image,
     BrowserTab,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageAssetDefinition {
+    pub id: CommandId,
+    pub title: String,
+    pub relative_path: String,
+    pub path: String,
 }
 
 pub const BROWSER_TAB_COMMAND_PREFIX: &str = "browser-tab";


### PR DESCRIPTION
## Summary
- add fixed image discovery under `/rayon/images` or `~/.config/rayon/images`
- index nested images by filename and relative path so they are searchable from the launcher
- copy selected image data to the macOS clipboard on Enter and close the launcher

## Testing
- pnpm check
- pnpm test
- pre-push hooks reran frontend and Rust test suites successfully

Closes #14