### PR TITLE
Add leading-space search for open windows and browser tabs

### DIFF
--- a/apps/desktop/src-tauri/src/app/adapters.rs
+++ b/apps/desktop/src-tauri/src/app/adapters.rs
@@ -2,7 +2,8 @@ use rayon_core::{AppPlatform, SearchIndex, SearchIndexStats};
 use rayon_db::TantivySearchIndex;
 use rayon_platform::MacOsAppManager;
 use rayon_types::{
-    BrowserTab, BrowserTabTarget, InstalledApp, ProcessMatch, SearchableItemDocument,
+    BrowserTab, BrowserTabTarget, InstalledApp, OpenWindow, OpenWindowTarget, ProcessMatch,
+    SearchableItemDocument,
 };
 
 pub(super) struct DesktopPlatform {
@@ -40,6 +41,14 @@ impl AppPlatform for DesktopPlatform {
 
     fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String> {
         self.inner.focus_browser_tab(target)
+    }
+
+    fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
+        self.inner.list_open_windows()
+    }
+
+    fn focus_open_window(&self, target: &OpenWindowTarget) -> Result<(), String> {
+        self.inner.focus_open_window(target)
     }
 
     fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String> {

--- a/apps/desktop/src-tauri/src/app/launcher.rs
+++ b/apps/desktop/src-tauri/src/app/launcher.rs
@@ -165,6 +165,14 @@ mod tests {
             Ok(())
         }
 
+        fn list_open_windows(&self) -> Result<Vec<rayon_types::OpenWindow>, String> {
+            Ok(Vec::new())
+        }
+
+        fn focus_open_window(&self, _target: &rayon_types::OpenWindowTarget) -> Result<(), String> {
+            Ok(())
+        }
+
         fn search_processes(&self, _query: &str) -> Result<Vec<ProcessMatch>, String> {
             Ok(Vec::new())
         }

--- a/apps/desktop/src-tauri/src/app/state.rs
+++ b/apps/desktop/src-tauri/src/app/state.rs
@@ -4,13 +4,14 @@ use rayon_features::{ClipboardHistoryService, ThemeSettingsStore};
 use rayon_types::{
     BrowserTab, CommandExecutionRequest, CommandExecutionResult, CommandInvocationResult,
     InteractiveSessionQueryRequest, InteractiveSessionState, InteractiveSessionSubmitRequest,
-    InteractiveSessionSubmitResult, SearchResult, SearchResultKind, SearchableItemDocument,
+    InteractiveSessionSubmitResult, OpenWindow, SearchResult, SearchResultKind,
+    SearchableItemDocument,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tauri::AppHandle;
 
-const BROWSER_TAB_SEARCH_LIMIT: usize = 20;
+const LEADING_SPACE_SEARCH_LIMIT: usize = 20;
 
 pub struct AppState {
     launcher: RwLock<LauncherService>,
@@ -18,7 +19,7 @@ pub struct AppState {
     search_index: Arc<dyn SearchIndex>,
     clipboard_history: Arc<ClipboardHistoryService>,
     theme_settings: Arc<ThemeSettingsStore>,
-    browser_tab_search_cache: Mutex<BrowserTabSearchCache>,
+    leading_space_search_cache: Mutex<LeadingSpaceSearchCache>,
 }
 
 impl AppState {
@@ -49,7 +50,7 @@ impl AppState {
             search_index: app_index,
             clipboard_history,
             theme_settings,
-            browser_tab_search_cache: Mutex::new(BrowserTabSearchCache::new()?),
+            leading_space_search_cache: Mutex::new(LeadingSpaceSearchCache::new()?),
         })
     }
 
@@ -68,10 +69,10 @@ impl AppState {
     }
 
     pub fn search_browser_tabs(&self, query: &str, refresh: bool) -> Vec<SearchResult> {
-        match self.browser_tab_search_cache.lock() {
+        match self.leading_space_search_cache.lock() {
             Ok(mut cache) => cache.search(self.platform.as_ref(), query, refresh),
             Err(poisoned) => {
-                eprintln!("browser tab search cache lock poisoned");
+                eprintln!("leading-space search cache lock poisoned");
                 poisoned
                     .into_inner()
                     .search(self.platform.as_ref(), query, refresh)
@@ -135,18 +136,18 @@ impl AppState {
     }
 }
 
-struct BrowserTabSearchCache {
-    tabs_by_id: HashMap<String, BrowserTab>,
-    ordered_tab_ids: Vec<String>,
+struct LeadingSpaceSearchCache {
+    items_by_id: HashMap<String, LeadingSpaceItem>,
+    ordered_item_ids: Vec<String>,
     search_index: rayon_db::TantivySearchIndex,
     initialized: bool,
 }
 
-impl BrowserTabSearchCache {
+impl LeadingSpaceSearchCache {
     fn new() -> Result<Self, String> {
         Ok(Self {
-            tabs_by_id: HashMap::new(),
-            ordered_tab_ids: Vec::new(),
+            items_by_id: HashMap::new(),
+            ordered_item_ids: Vec::new(),
             search_index: rayon_db::TantivySearchIndex::create_in_memory()
                 .map_err(|error| error.to_string())?,
             initialized: false,
@@ -161,7 +162,7 @@ impl BrowserTabSearchCache {
     ) -> Vec<SearchResult> {
         if refresh || !self.initialized {
             if let Err(error) = self.refresh(platform) {
-                eprintln!("browser tab refresh failed: {error}");
+                eprintln!("leading-space refresh failed: {error}");
                 return Vec::new();
             }
         }
@@ -169,80 +170,156 @@ impl BrowserTabSearchCache {
         let normalized_query = query.trim();
         if normalized_query.is_empty() {
             return self
-                .ordered_tab_ids
+                .ordered_item_ids
                 .iter()
-                .take(BROWSER_TAB_SEARCH_LIMIT)
-                .filter_map(|tab_id| self.tabs_by_id.get(tab_id))
-                .cloned()
-                .map(browser_tab_search_result)
+                .take(LEADING_SPACE_SEARCH_LIMIT)
+                .filter_map(|item_id| self.items_by_id.get(item_id))
+                .map(LeadingSpaceItem::search_result)
                 .collect();
         }
 
         let item_ids = match self
             .search_index
-            .search_item_ids(normalized_query, BROWSER_TAB_SEARCH_LIMIT)
+            .search_item_ids(normalized_query, LEADING_SPACE_SEARCH_LIMIT)
         {
             Ok(item_ids) => item_ids,
             Err(error) => {
-                eprintln!("browser tab index search failed: {error}");
+                eprintln!("leading-space index search failed: {error}");
                 return Vec::new();
             }
         };
 
-        item_ids
+        let mut matches = item_ids
             .into_iter()
-            .filter_map(|item_id| self.tabs_by_id.get(&item_id))
-            .cloned()
-            .map(browser_tab_search_result)
-            .collect()
+            .enumerate()
+            .filter_map(|(index, item_id)| {
+                self.items_by_id
+                    .get(&item_id)
+                    .map(|item| (leading_space_sort_key(item, index), item.search_result()))
+            })
+            .collect::<Vec<_>>();
+        matches.sort_by(|left, right| left.0.cmp(&right.0));
+        matches.into_iter().map(|(_, result)| result).collect()
     }
 
     fn refresh(&mut self, platform: &dyn AppPlatform) -> Result<(), String> {
         let tabs = platform.search_browser_tabs("")?;
-        let documents = tabs
+        let windows = platform.list_open_windows()?;
+        let ordered_item_ids = windows
             .iter()
-            .map(|tab| SearchableItemDocument {
-                id: tab.command_id(),
-                kind: SearchResultKind::BrowserTab,
-                title: tab.title.clone(),
-                subtitle: Some(tab.subtitle()),
-                owner_plugin_id: None,
-                search_text: tab.search_text(),
-            })
+            .map(OpenWindow::command_id)
+            .chain(tabs.iter().map(BrowserTab::command_id))
+            .map(|id| id.to_string())
             .collect::<Vec<_>>();
+
+        let mut documents = windows
+            .iter()
+            .map(LeadingSpaceItem::window_search_document)
+            .collect::<Vec<_>>();
+        documents.extend(
+            tabs.iter()
+                .map(LeadingSpaceItem::tab_search_document)
+                .collect::<Vec<_>>(),
+        );
 
         self.search_index
             .replace_items(&documents)
             .map_err(|error| error.to_string())?;
 
-        self.tabs_by_id = tabs
-            .iter()
-            .cloned()
-            .map(|tab| (tab.command_id().to_string(), tab))
-            .collect();
-        self.ordered_tab_ids = tabs
+        self.items_by_id = windows
             .into_iter()
-            .map(|tab| tab.command_id().to_string())
+            .map(|window| {
+                let item = LeadingSpaceItem::OpenWindow(window);
+                (item.id().to_string(), item)
+            })
+            .chain(tabs.into_iter().map(|tab| {
+                let item = LeadingSpaceItem::BrowserTab(tab);
+                (item.id().to_string(), item)
+            }))
             .collect();
+
+        self.ordered_item_ids = ordered_item_ids;
         self.initialized = true;
         Ok(())
     }
 }
 
-fn browser_tab_search_result(tab: BrowserTab) -> SearchResult {
-    let subtitle = tab.subtitle();
-    SearchResult {
-        id: tab.command_id(),
-        title: tab.title,
-        subtitle: Some(subtitle),
-        icon_path: None,
-        kind: SearchResultKind::BrowserTab,
-        owner_plugin_id: None,
-        keywords: Vec::new(),
-        starts_interactive_session: false,
-        close_launcher_on_success: true,
-        input_mode: rayon_types::CommandInputMode::Structured,
-        arguments: Vec::new(),
+#[derive(Clone)]
+enum LeadingSpaceItem {
+    BrowserTab(BrowserTab),
+    OpenWindow(OpenWindow),
+}
+
+impl LeadingSpaceItem {
+    fn id(&self) -> rayon_types::CommandId {
+        match self {
+            Self::BrowserTab(tab) => tab.command_id(),
+            Self::OpenWindow(window) => window.command_id(),
+        }
+    }
+
+    fn search_result(&self) -> SearchResult {
+        match self {
+            Self::BrowserTab(tab) => SearchResult {
+                id: tab.command_id(),
+                title: tab.title.clone(),
+                subtitle: Some(tab.subtitle()),
+                icon_path: None,
+                kind: SearchResultKind::BrowserTab,
+                owner_plugin_id: None,
+                keywords: Vec::new(),
+                starts_interactive_session: false,
+                close_launcher_on_success: true,
+                input_mode: rayon_types::CommandInputMode::Structured,
+                arguments: Vec::new(),
+            },
+            Self::OpenWindow(window) => SearchResult {
+                id: window.command_id(),
+                title: window.display_title(),
+                subtitle: Some(window.subtitle()),
+                icon_path: None,
+                kind: SearchResultKind::OpenWindow,
+                owner_plugin_id: None,
+                keywords: Vec::new(),
+                starts_interactive_session: false,
+                close_launcher_on_success: true,
+                input_mode: rayon_types::CommandInputMode::Structured,
+                arguments: Vec::new(),
+            },
+        }
+    }
+
+    fn tab_search_document(tab: &BrowserTab) -> SearchableItemDocument {
+        SearchableItemDocument {
+            id: tab.command_id(),
+            kind: SearchResultKind::BrowserTab,
+            title: tab.title.clone(),
+            subtitle: Some(tab.subtitle()),
+            owner_plugin_id: None,
+            search_text: tab.search_text(),
+        }
+    }
+
+    fn window_search_document(window: &OpenWindow) -> SearchableItemDocument {
+        SearchableItemDocument {
+            id: window.command_id(),
+            kind: SearchResultKind::OpenWindow,
+            title: window.display_title(),
+            subtitle: Some(window.subtitle()),
+            owner_plugin_id: None,
+            search_text: window.search_text(),
+        }
+    }
+}
+
+fn leading_space_sort_key(item: &LeadingSpaceItem, original_index: usize) -> (u8, u8, usize) {
+    match item {
+        LeadingSpaceItem::OpenWindow(window) => {
+            (0, if window.is_frontmost { 0 } else { 1 }, original_index)
+        }
+        LeadingSpaceItem::BrowserTab(tab) => {
+            (1, if tab.is_active() { 0 } else { 1 }, original_index)
+        }
     }
 }
 
@@ -260,11 +337,14 @@ pub fn write_launcher(launcher: &RwLock<LauncherService>) -> RwLockWriteGuard<'_
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use rayon_types::{BrowserTabTarget, CommandId, InstalledApp, ProcessMatch};
+    use rayon_types::{
+        BrowserTabTarget, CommandId, InstalledApp, OpenWindow, OpenWindowTarget, ProcessMatch,
+    };
     use std::sync::Mutex;
 
     struct StubPlatform {
         browser_tabs: Mutex<Vec<BrowserTab>>,
+        open_windows: Mutex<Vec<OpenWindow>>,
         search_calls: Mutex<usize>,
     }
 
@@ -294,6 +374,15 @@ mod tests {
             Ok(())
         }
 
+        fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
+            *self.search_calls.lock().unwrap() += 1;
+            Ok(self.open_windows.lock().unwrap().clone())
+        }
+
+        fn focus_open_window(&self, _target: &OpenWindowTarget) -> Result<(), String> {
+            Ok(())
+        }
+
         fn search_processes(&self, _query: &str) -> Result<Vec<ProcessMatch>, String> {
             Ok(Vec::new())
         }
@@ -315,8 +404,21 @@ mod tests {
         }
     }
 
+    fn sample_window(title: &str, application: &str, pid: i32, frontmost: bool) -> OpenWindow {
+        OpenWindow {
+            application: application.into(),
+            pid,
+            bounds_x: pid * 10,
+            bounds_y: pid * 10,
+            bounds_width: 1440,
+            bounds_height: 900,
+            title: title.into(),
+            is_frontmost: frontmost,
+        }
+    }
+
     #[test]
-    fn browser_tab_search_cache_refreshes_only_on_request() {
+    fn leading_space_search_cache_refreshes_only_on_request() {
         let platform = StubPlatform {
             browser_tabs: Mutex::new(vec![sample_tab(
                 "Issue 15",
@@ -324,61 +426,92 @@ mod tests {
                 1,
                 1,
             )]),
+            open_windows: Mutex::new(vec![sample_window("Rayon", "Arc", 101, true)]),
             search_calls: Mutex::new(0),
         };
-        let mut cache = BrowserTabSearchCache::new().unwrap();
+        let mut cache = LeadingSpaceSearchCache::new().unwrap();
 
         let first_results = cache.search(&platform, "issue", true);
         let second_results = cache.search(&platform, "rayon", false);
 
         assert_eq!(first_results.len(), 1);
-        assert_eq!(second_results.len(), 1);
-        assert_eq!(*platform.search_calls.lock().unwrap(), 1);
+        assert_eq!(second_results.len(), 2);
+        assert_eq!(*platform.search_calls.lock().unwrap(), 2);
     }
 
     #[test]
-    fn browser_tab_search_cache_replaces_stale_tabs_on_refresh() {
+    fn leading_space_search_cache_replaces_stale_items_on_refresh() {
         let platform = StubPlatform {
             browser_tabs: Mutex::new(vec![sample_tab("Old Tab", "https://old.example", 1, 1)]),
+            open_windows: Mutex::new(vec![sample_window("Old Window", "Arc", 202, true)]),
             search_calls: Mutex::new(0),
         };
-        let mut cache = BrowserTabSearchCache::new().unwrap();
+        let mut cache = LeadingSpaceSearchCache::new().unwrap();
 
         let old_results = cache.search(&platform, "old", true);
-        assert_eq!(old_results[0].title, "Old Tab");
+        assert_eq!(old_results.len(), 2);
 
         *platform.browser_tabs.lock().unwrap() =
             vec![sample_tab("Fresh Tab", "https://fresh.example/path", 1, 1)];
+        *platform.open_windows.lock().unwrap() =
+            vec![sample_window("Fresh Window", "Finder", 303, true)];
 
         let stale_results = cache.search(&platform, "fresh", false);
         assert!(stale_results.is_empty());
 
         let fresh_results = cache.search(&platform, "fresh", true);
-        assert_eq!(fresh_results[0].title, "Fresh Tab");
-        assert_eq!(*platform.search_calls.lock().unwrap(), 2);
+        assert_eq!(fresh_results.len(), 2);
+        assert_eq!(*platform.search_calls.lock().unwrap(), 4);
     }
 
     #[test]
-    fn browser_tab_search_cache_returns_all_tabs_for_blank_query() {
+    fn leading_space_search_cache_returns_windows_then_tabs_for_blank_query() {
         let platform = StubPlatform {
             browser_tabs: Mutex::new(vec![
                 sample_tab("Current", "https://current.example", 1, 1),
                 sample_tab("Other", "https://other.example", 2, 1),
             ]),
+            open_windows: Mutex::new(vec![
+                sample_window("Project", "Arc", 404, true),
+                sample_window("Notes", "Obsidian", 505, false),
+            ]),
             search_calls: Mutex::new(0),
         };
-        let mut cache = BrowserTabSearchCache::new().unwrap();
+        let mut cache = LeadingSpaceSearchCache::new().unwrap();
 
         let results = cache.search(&platform, "", true);
 
-        assert_eq!(results.len(), 2);
+        assert_eq!(results.len(), 4);
+        assert_eq!(results[0].kind, SearchResultKind::OpenWindow);
         assert_eq!(
             results[0].id,
+            CommandId::from("open-window:404:4040:4040:1440:900")
+        );
+        assert_eq!(results[2].kind, SearchResultKind::BrowserTab);
+        assert_eq!(
+            results[2].id,
             CommandId::from("browser-tab:chrome:window-1:1")
         );
-        assert_eq!(
-            results[1].id,
-            CommandId::from("browser-tab:chrome:window-2:1")
-        );
+    }
+
+    #[test]
+    fn leading_space_search_prioritizes_windows_over_tabs_for_matching_queries() {
+        let platform = StubPlatform {
+            browser_tabs: Mutex::new(vec![sample_tab(
+                "Project Docs",
+                "https://example.com/docs",
+                1,
+                1,
+            )]),
+            open_windows: Mutex::new(vec![sample_window("Project Board", "Linear", 606, true)]),
+            search_calls: Mutex::new(0),
+        };
+        let mut cache = LeadingSpaceSearchCache::new().unwrap();
+
+        let results = cache.search(&platform, "project", true);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].kind, SearchResultKind::OpenWindow);
+        assert_eq!(results[1].kind, SearchResultKind::BrowserTab);
     }
 }

--- a/apps/desktop/src-tauri/src/app/state.rs
+++ b/apps/desktop/src-tauri/src/app/state.rs
@@ -408,6 +408,7 @@ mod tests {
         OpenWindow {
             application: application.into(),
             pid,
+            window_number: pid * 100,
             bounds_x: pid * 10,
             bounds_y: pid * 10,
             bounds_width: 1440,
@@ -485,7 +486,7 @@ mod tests {
         assert_eq!(results[0].kind, SearchResultKind::OpenWindow);
         assert_eq!(
             results[0].id,
-            CommandId::from("open-window:404:4040:4040:1440:900")
+            CommandId::from("open-window:404:40400:4040:4040:1440:900")
         );
         assert_eq!(results[2].kind, SearchResultKind::BrowserTab);
         assert_eq!(

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -212,7 +212,7 @@ describe("App", () => {
     expect(await screen.findByText("Issue 15")).toBeTruthy();
     expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("issue", true);
     expect(launcherApi.searchLauncher).not.toHaveBeenCalled();
-    expect(input.getAttribute("placeholder")).toBe("Search open Chrome tabs");
+    expect(input.getAttribute("placeholder")).toBe("Search open windows and tabs");
     expect(input.getAttribute("data-mode")).toBe("browser_tabs");
   });
 
@@ -236,6 +236,26 @@ describe("App", () => {
     expect(await screen.findByText("Image")).toBeTruthy();
   });
 
+  it("renders leading-space window results with the window badge", async () => {
+    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
+      searchResult({
+        id: "open-window:4242:10:20:1440:900",
+        title: "Project Board",
+        subtitle: "Linear",
+        kind: "open_window",
+        close_launcher_on_success: true,
+      }),
+    ]);
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: " project" } });
+
+    expect(await screen.findByText("Project Board")).toBeTruthy();
+    expect(await screen.findByText("Window")).toBeTruthy();
+  });
+
   it("shows all tabs when the query is only a leading space", async () => {
     vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
       searchResult({
@@ -254,7 +274,7 @@ describe("App", () => {
 
     expect(await screen.findByText("Rayon")).toBeTruthy();
     expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("", true);
-    expect(input.getAttribute("placeholder")).toBe("Search open Chrome tabs");
+    expect(input.getAttribute("placeholder")).toBe("Search open windows and tabs");
   });
 
   it("refreshes browser tabs only when entering tab mode", async () => {

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -239,7 +239,7 @@ describe("App", () => {
   it("renders leading-space window results with the window badge", async () => {
     vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
       searchResult({
-        id: "open-window:4242:10:20:1440:900",
+        id: "open-window:4242:777:10:20:1440:900",
         title: "Project Board",
         subtitle: "Linear",
         kind: "open_window",

--- a/apps/desktop/src/commandExecution.ts
+++ b/apps/desktop/src/commandExecution.ts
@@ -16,7 +16,7 @@ export type SearchResult = {
   title: string;
   subtitle: string | null;
   icon_path: string | null;
-  kind: "command" | "application" | "bookmark" | "image" | "browser_tab";
+  kind: "command" | "application" | "bookmark" | "image" | "browser_tab" | "open_window";
   owner_plugin_id: string | null;
   keywords: string[];
   starts_interactive_session: boolean;

--- a/apps/desktop/src/features/launcher/copy.ts
+++ b/apps/desktop/src/features/launcher/copy.ts
@@ -40,6 +40,9 @@ export function getInteractiveSubmitHint(session: InteractiveSessionState): stri
 }
 
 export function getSearchResultKind(result: SearchResult): string {
+  if (result.kind === "open_window") {
+    return "Window";
+  }
   if (result.kind === "browser_tab") {
     return "Tab";
   }

--- a/apps/desktop/src/features/launcher/useLauncherController.ts
+++ b/apps/desktop/src/features/launcher/useLauncherController.ts
@@ -722,7 +722,7 @@ export function useLauncherController(): LauncherController {
       : interactiveSession
         ? interactiveSession.input_placeholder
         : inputMode === "browser_tabs"
-          ? "Search open Chrome tabs"
+          ? "Search open windows and tabs"
           : "Type a command",
     inputMode,
     onQueryChange,

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -1,7 +1,7 @@
 use rayon_types::{
     BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandId, CommandInputMode,
-    ImageAssetDefinition, InstalledApp, ProcessMatch, SearchIndexStats, SearchResult,
-    SearchResultKind, SearchableItemDocument,
+    ImageAssetDefinition, InstalledApp, OpenWindow, OpenWindowTarget, ProcessMatch,
+    SearchIndexStats, SearchResult, SearchResultKind, SearchableItemDocument,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -13,6 +13,8 @@ pub trait AppPlatform: Send + Sync {
     fn copy_image_to_clipboard(&self, image_path: &Path) -> Result<(), String>;
     fn search_browser_tabs(&self, query: &str) -> Result<Vec<BrowserTab>, String>;
     fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String>;
+    fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String>;
+    fn focus_open_window(&self, target: &OpenWindowTarget) -> Result<(), String>;
     fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String>;
     fn terminate_process(&self, pid: u32) -> Result<(), String>;
 }

--- a/crates/core/src/launcher/execution.rs
+++ b/crates/core/src/launcher/execution.rs
@@ -36,6 +36,12 @@ impl LauncherService {
                     output: result.output,
                 })
             }
+            ExecutionTarget::OpenWindow(target) => {
+                let result = self.focus_open_window(&target)?;
+                Ok(CommandInvocationResult::Completed {
+                    output: result.output,
+                })
+            }
             ExecutionTarget::Bookmark(bookmark_id) => {
                 let result = self.open_bookmark(&bookmark_id)?;
                 Ok(CommandInvocationResult::Completed {
@@ -132,6 +138,19 @@ impl LauncherService {
 
         Ok(CommandExecutionResult {
             output: "focused Chrome tab".into(),
+        })
+    }
+
+    fn focus_open_window(
+        &self,
+        target: &rayon_types::OpenWindowTarget,
+    ) -> Result<CommandExecutionResult, LauncherError> {
+        self.platform
+            .focus_open_window(target)
+            .map_err(LauncherError::Platform)?;
+
+        Ok(CommandExecutionResult {
+            output: "focused window".into(),
         })
     }
 

--- a/crates/core/src/launcher/routing.rs
+++ b/crates/core/src/launcher/routing.rs
@@ -1,10 +1,14 @@
 use crate::commands::APP_REINDEX_COMMAND_ID;
-use rayon_types::{parse_browser_tab_command_id, BrowserTabTarget, CommandId};
+use rayon_types::{
+    parse_browser_tab_command_id, parse_open_window_command_id, BrowserTabTarget, CommandId,
+    OpenWindowTarget,
+};
 
 pub(super) enum ExecutionTarget {
     Reindex,
     App(CommandId),
     BrowserTab(BrowserTabTarget),
+    OpenWindow(OpenWindowTarget),
     Bookmark(CommandId),
     Image(CommandId),
     Provider(CommandId),
@@ -25,6 +29,10 @@ pub(super) fn resolve_execution_target(
 
     if let Some(target) = parse_browser_tab_command_id(command_id) {
         return ExecutionTarget::BrowserTab(target);
+    }
+
+    if let Some(target) = parse_open_window_command_id(command_id) {
+        return ExecutionTarget::OpenWindow(target);
     }
 
     if bookmark_exists {

--- a/crates/core/src/launcher/tests.rs
+++ b/crates/core/src/launcher/tests.rs
@@ -230,6 +230,7 @@ fn execute_routes_open_window_ids_to_platform_focus() {
         open_windows: Mutex::new(vec![OpenWindow {
             application: "Arc".into(),
             pid: 4242,
+            window_number: 777,
             bounds_x: 10,
             bounds_y: 20,
             bounds_width: 1440,
@@ -245,7 +246,7 @@ fn execute_routes_open_window_ids_to_platform_focus() {
 
     let result = launcher
         .execute_command(&CommandExecutionRequest {
-            command_id: CommandId::from("open-window:4242:10:20:1440:900"),
+            command_id: CommandId::from("open-window:4242:777:10:20:1440:900"),
             argv: Vec::new(),
             arguments: HashMap::new(),
         })
@@ -263,6 +264,7 @@ fn execute_routes_open_window_ids_to_platform_focus() {
         focused,
         &OpenWindowTarget {
             pid: 4242,
+            window_number: Some(777),
             bounds_x: 10,
             bounds_y: 20,
             bounds_width: 1440,

--- a/crates/core/src/launcher/tests.rs
+++ b/crates/core/src/launcher/tests.rs
@@ -10,7 +10,7 @@ use rayon_types::{
     CommandId, CommandInputMode, CommandInvocationResult, ImageAssetDefinition,
     InteractiveSessionCompletionBehavior, InteractiveSessionMetadata,
     InteractiveSessionQueryRequest, InteractiveSessionResult, InteractiveSessionSubmitRequest,
-    InteractiveSessionSubmitResult, SearchResultKind,
+    InteractiveSessionSubmitResult, OpenWindow, OpenWindowTarget, SearchResultKind,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -90,6 +90,8 @@ fn aggregate_search_does_not_include_browser_tabs() {
             url: "https://example.com/arc".into(),
         }]),
         focused_browser_tabs: Mutex::new(Vec::new()),
+        open_windows: Mutex::new(Vec::new()),
+        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -182,6 +184,8 @@ fn execute_routes_browser_tab_ids_to_platform_focus() {
             url: "https://github.com/alexandrelam/rayon/issues/15".into(),
         }]),
         focused_browser_tabs: Mutex::new(Vec::new()),
+        open_windows: Mutex::new(Vec::new()),
+        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -209,6 +213,60 @@ fn execute_routes_browser_tab_ids_to_platform_focus() {
             browser: "chrome".into(),
             window_id: "window-1".into(),
             tab_index: 4,
+        }
+    );
+}
+
+#[allow(clippy::unwrap_used)]
+#[test]
+fn execute_routes_open_window_ids_to_platform_focus() {
+    let platform = Arc::new(StubPlatform {
+        apps: Vec::new(),
+        launched: Mutex::new(Vec::new()),
+        opened_urls: Mutex::new(Vec::new()),
+        copied_images: Mutex::new(Vec::new()),
+        browser_tabs: Mutex::new(Vec::new()),
+        focused_browser_tabs: Mutex::new(Vec::new()),
+        open_windows: Mutex::new(vec![OpenWindow {
+            application: "Arc".into(),
+            pid: 4242,
+            bounds_x: 10,
+            bounds_y: 20,
+            bounds_width: 1440,
+            bounds_height: 900,
+            title: "Rayon".into(),
+            is_frontmost: true,
+        }]),
+        focused_open_windows: Mutex::new(Vec::new()),
+        process_search_results: Mutex::new(Vec::new()),
+        terminated_pids: Mutex::new(Vec::new()),
+    });
+    let launcher = launcher_with_platform(platform.clone(), vec![]);
+
+    let result = launcher
+        .execute_command(&CommandExecutionRequest {
+            command_id: CommandId::from("open-window:4242:10:20:1440:900"),
+            argv: Vec::new(),
+            arguments: HashMap::new(),
+        })
+        .unwrap();
+
+    assert_eq!(
+        result,
+        CommandInvocationResult::Completed {
+            output: "focused window".into()
+        }
+    );
+
+    let focused = &platform.focused_open_windows.lock().unwrap()[0];
+    assert_eq!(
+        focused,
+        &OpenWindowTarget {
+            pid: 4242,
+            bounds_x: 10,
+            bounds_y: 20,
+            bounds_width: 1440,
+            bounds_height: 900,
         }
     );
 }
@@ -307,6 +365,8 @@ fn completed_interactive_submit_removes_active_session() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
+        open_windows: Mutex::new(Vec::new()),
+        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -452,6 +512,8 @@ fn completed_interactive_submit_calls_provider_cleanup() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
+        open_windows: Mutex::new(Vec::new()),
+        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -508,6 +570,8 @@ fn startup_reindexes_commands_and_apps() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
+        open_windows: Mutex::new(Vec::new()),
+        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -577,6 +641,8 @@ fn aggregate_search_includes_images() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
+        open_windows: Mutex::new(Vec::new()),
+        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -618,6 +684,8 @@ fn execute_routes_image_ids_to_clipboard_copy() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
+        open_windows: Mutex::new(Vec::new()),
+        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });

--- a/crates/core/src/test_support.rs
+++ b/crates/core/src/test_support.rs
@@ -8,7 +8,8 @@ use rayon_types::{
     BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandArgumentDefinition,
     CommandArgumentType, CommandDefinition, CommandExecutionRequest, CommandExecutionResult,
     CommandId, CommandInputMode, InstalledApp, InteractiveSessionCompletionBehavior,
-    InteractiveSessionMetadata, InteractiveSessionResult, ProcessMatch, SearchableItemDocument,
+    InteractiveSessionMetadata, InteractiveSessionResult, OpenWindow, OpenWindowTarget,
+    ProcessMatch, SearchableItemDocument,
 };
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -181,6 +182,8 @@ pub(crate) struct StubPlatform {
     pub copied_images: Mutex<Vec<String>>,
     pub browser_tabs: Mutex<Vec<BrowserTab>>,
     pub focused_browser_tabs: Mutex<Vec<BrowserTabTarget>>,
+    pub open_windows: Mutex<Vec<OpenWindow>>,
+    pub focused_open_windows: Mutex<Vec<OpenWindowTarget>>,
     pub process_search_results: Mutex<Vec<ProcessMatch>>,
     pub terminated_pids: Mutex<Vec<u32>>,
 }
@@ -222,6 +225,18 @@ impl AppPlatform for StubPlatform {
 
     fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String> {
         self.focused_browser_tabs
+            .lock()
+            .unwrap()
+            .push(target.clone());
+        Ok(())
+    }
+
+    fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
+        Ok(self.open_windows.lock().unwrap().clone())
+    }
+
+    fn focus_open_window(&self, target: &OpenWindowTarget) -> Result<(), String> {
+        self.focused_open_windows
             .lock()
             .unwrap()
             .push(target.clone());
@@ -279,6 +294,8 @@ pub(crate) fn build_launcher_service(search_results: Vec<String>) -> LauncherSer
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
+        open_windows: Mutex::new(Vec::new()),
+        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -265,6 +265,7 @@ fn search_kind(kind: SearchResultKind) -> &'static str {
         SearchResultKind::Bookmark => "bookmark",
         SearchResultKind::Image => "image",
         SearchResultKind::BrowserTab => "browser_tab",
+        SearchResultKind::OpenWindow => "open_window",
     }
 }
 

--- a/crates/features/src/github.rs
+++ b/crates/features/src/github.rs
@@ -349,6 +349,14 @@ mod tests {
             Ok(())
         }
 
+        fn list_open_windows(&self) -> Result<Vec<rayon_types::OpenWindow>, String> {
+            Ok(Vec::new())
+        }
+
+        fn focus_open_window(&self, _target: &rayon_types::OpenWindowTarget) -> Result<(), String> {
+            Ok(())
+        }
+
         fn search_processes(&self, _query: &str) -> Result<Vec<ProcessMatch>, String> {
             Ok(Vec::new())
         }

--- a/crates/features/src/lib.rs
+++ b/crates/features/src/lib.rs
@@ -31,7 +31,9 @@ pub fn built_in_providers(deps: BuiltInDependencies) -> Vec<Arc<dyn CommandProvi
 mod tests {
     use super::*;
     use rayon_core::CommandRegistry;
-    use rayon_types::{BrowserTab, BrowserTabTarget, CommandId, ProcessMatch};
+    use rayon_types::{
+        BrowserTab, BrowserTabTarget, CommandId, OpenWindow, OpenWindowTarget, ProcessMatch,
+    };
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -59,6 +61,14 @@ mod tests {
         }
 
         fn focus_browser_tab(&self, _target: &BrowserTabTarget) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
+            Ok(Vec::new())
+        }
+
+        fn focus_open_window(&self, _target: &OpenWindowTarget) -> Result<(), String> {
             Ok(())
         }
 

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -59,8 +59,6 @@ const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
 #[cfg(target_os = "macos")]
 const K_CF_NUMBER_SINT32_TYPE: i32 = 3;
 #[cfg(target_os = "macos")]
-const K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY: u32 = 1 << 0;
-#[cfg(target_os = "macos")]
 const K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS: u32 = 1 << 4;
 
 #[cfg(target_os = "macos")]
@@ -69,6 +67,7 @@ extern "C" {
     static kCGWindowOwnerPID: CFStringRef;
     static kCGWindowOwnerName: CFStringRef;
     static kCGWindowName: CFStringRef;
+    static kCGWindowNumber: CFStringRef;
     static kCGWindowBounds: CFStringRef;
     static kCGWindowLayer: CFStringRef;
 
@@ -206,11 +205,8 @@ impl MacOsAppManager {
         #[cfg(target_os = "macos")]
         {
             let window_list = unsafe {
-                CGWindowListCopyWindowInfo(
-                    K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY
-                        | K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS,
-                    0,
-                )
+                // Use the full window list so windows from other Spaces are indexed too.
+                CGWindowListCopyWindowInfo(K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS, 0)
             };
             if window_list.is_null() {
                 return Err("failed to list open windows".into());
@@ -612,6 +608,11 @@ fn parse_open_window(dictionary: CFDictionaryRef) -> Option<OpenWindow> {
         return None;
     }
 
+    let window_number = cf_dictionary_i32(dictionary, unsafe { kCGWindowNumber })?;
+    if window_number <= 0 {
+        return None;
+    }
+
     let application = cf_dictionary_string(dictionary, unsafe { kCGWindowOwnerName })?;
     if application.is_empty() || application == "Rayon" {
         return None;
@@ -634,6 +635,7 @@ fn parse_open_window(dictionary: CFDictionaryRef) -> Option<OpenWindow> {
     Some(OpenWindow {
         application,
         pid,
+        window_number,
         bounds_x,
         bounds_y,
         bounds_width,
@@ -717,6 +719,7 @@ fn cf_string_to_string(value: CFStringRef) -> Option<String> {
 
 fn focus_open_window_script(target: &OpenWindowTarget) -> String {
     let pid = target.pid;
+    let window_number = target.window_number.unwrap_or_default();
     let x = target.bounds_x;
     let y = target.bounds_y;
     let width = target.bounds_width;
@@ -727,19 +730,36 @@ fn focus_open_window_script(target: &OpenWindowTarget) -> String {
         r#"
 tell application "System Events"
     if UI elements enabled is false then
-        error "Rayon needs Accessibility access to focus windows"
+        error "Rayon needs Accessibility access to focus windows across Spaces"
     end if
 
     if not (exists first application process whose unix id is {pid}) then
         error "Window application is no longer running"
     end if
 
+    set targetProcess to first application process whose unix id is {pid}
+    set targetAppName to name of targetProcess
+end tell
+
+tell application targetAppName
+    activate
+end tell
+
+delay 0.05
+
+tell application "System Events"
     tell first application process whose unix id is {pid}
         set frontmost to true
         repeat with w in windows
             set windowPosition to position of w
             set windowSize to size of w
-            if (abs((item 1 of windowPosition) - {x}) <= {tolerance}) and (abs((item 2 of windowPosition) - {y}) <= {tolerance}) and (abs((item 1 of windowSize) - {width}) <= {tolerance}) and (abs((item 2 of windowSize) - {height}) <= {tolerance}) then
+            set titleMatches to false
+            try
+                if value of attribute "AXWindowNumber" of w is {window_number} then
+                    set titleMatches to true
+                end if
+            end try
+            if titleMatches or ((abs((item 1 of windowPosition) - {x}) <= {tolerance}) and (abs((item 2 of windowPosition) - {y}) <= {tolerance}) and (abs((item 1 of windowSize) - {width}) <= {tolerance}) and (abs((item 2 of windowSize) - {height}) <= {tolerance})) then
                 perform action "AXRaise" of w
                 set value of attribute "AXMain" of w to true
                 return "ok"
@@ -1132,5 +1152,22 @@ mod tests {
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].title, "Second");
         assert_eq!(matches[1].title, "First");
+    }
+
+    #[test]
+    fn open_window_focus_script_activates_app_and_prefers_window_number() {
+        let script = focus_open_window_script(&OpenWindowTarget {
+            pid: 4242,
+            window_number: Some(777),
+            bounds_x: 10,
+            bounds_y: 20,
+            bounds_width: 1440,
+            bounds_height: 900,
+        });
+
+        assert!(script.contains("tell application targetAppName"));
+        assert!(script.contains("activate"));
+        assert!(script.contains("AXWindowNumber"));
+        assert!(script.contains("is 777"));
     }
 }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -1,9 +1,12 @@
 use plist::Value;
-use rayon_types::{BrowserTab, BrowserTabTarget, CommandId, InstalledApp, ProcessMatch};
+use rayon_types::{
+    BrowserTab, BrowserTabTarget, CommandId, InstalledApp, OpenWindow, OpenWindowTarget,
+    ProcessMatch,
+};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::ffi::OsStr;
+use std::ffi::{c_char, c_void, CStr, OsStr};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -14,6 +17,79 @@ const APPLICATIONS_DIR: &str = "/Applications";
 const SYSTEM_APPLICATIONS_DIR: &str = "/System/Applications";
 const APPLE_SCRIPT_FIELD_SEPARATOR: char = '\u{001f}';
 const APPLE_SCRIPT_RECORD_SEPARATOR: char = '\u{001e}';
+const OPEN_WINDOW_MATCH_TOLERANCE: i32 = 2;
+
+#[cfg(target_os = "macos")]
+type CFTypeRef = *const c_void;
+#[cfg(target_os = "macos")]
+type CFArrayRef = *const c_void;
+#[cfg(target_os = "macos")]
+type CFDictionaryRef = *const c_void;
+#[cfg(target_os = "macos")]
+type CFStringRef = *const c_void;
+#[cfg(target_os = "macos")]
+type CFNumberRef = *const c_void;
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct CGPoint {
+    x: f64,
+    y: f64,
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct CGSize {
+    width: f64,
+    height: f64,
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct CGRect {
+    origin: CGPoint,
+    size: CGSize,
+}
+
+#[cfg(target_os = "macos")]
+const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+#[cfg(target_os = "macos")]
+const K_CF_NUMBER_SINT32_TYPE: i32 = 3;
+#[cfg(target_os = "macos")]
+const K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY: u32 = 1 << 0;
+#[cfg(target_os = "macos")]
+const K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS: u32 = 1 << 4;
+
+#[cfg(target_os = "macos")]
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    static kCGWindowOwnerPID: CFStringRef;
+    static kCGWindowOwnerName: CFStringRef;
+    static kCGWindowName: CFStringRef;
+    static kCGWindowBounds: CFStringRef;
+    static kCGWindowLayer: CFStringRef;
+
+    fn CGWindowListCopyWindowInfo(option: u32, relative_to_window: u32) -> CFArrayRef;
+    fn CGRectMakeWithDictionaryRepresentation(dict: CFDictionaryRef, rect: *mut CGRect) -> bool;
+    fn CFArrayGetCount(the_array: CFArrayRef) -> isize;
+    fn CFArrayGetValueAtIndex(the_array: CFArrayRef, idx: isize) -> *const c_void;
+    fn CFDictionaryGetValueIfPresent(
+        the_dict: CFDictionaryRef,
+        key: *const c_void,
+        value: *mut *const c_void,
+    ) -> u8;
+    fn CFNumberGetValue(number: CFNumberRef, the_type: i32, value_ptr: *mut c_void) -> u8;
+    fn CFRelease(cf: CFTypeRef);
+    fn CFStringGetCString(
+        the_string: CFStringRef,
+        buffer: *mut c_char,
+        buffer_size: isize,
+        encoding: u32,
+    ) -> u8;
+}
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MacOsAppManager;
@@ -119,6 +195,71 @@ impl MacOsAppManager {
         }
 
         Err(last_error.unwrap_or_else(|| "failed to focus Chrome tab".to_string()))
+    }
+
+    pub fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
+        #[cfg(not(target_os = "macos"))]
+        {
+            Ok(Vec::new())
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let window_list = unsafe {
+                CGWindowListCopyWindowInfo(
+                    K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY
+                        | K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS,
+                    0,
+                )
+            };
+            if window_list.is_null() {
+                return Err("failed to list open windows".into());
+            }
+
+            let _window_list_guard = CfReleaseGuard(window_list);
+            let mut windows = Vec::new();
+            let mut frontmost_available = true;
+            let count = unsafe { CFArrayGetCount(window_list) };
+            for index in 0..count {
+                let dictionary =
+                    unsafe { CFArrayGetValueAtIndex(window_list, index) as CFDictionaryRef };
+                if dictionary.is_null() {
+                    continue;
+                }
+
+                if let Some(mut window) = parse_open_window(dictionary) {
+                    if frontmost_available {
+                        window.is_frontmost = true;
+                        frontmost_available = false;
+                    }
+                    windows.push(window);
+                }
+            }
+
+            Ok(windows)
+        }
+    }
+
+    pub fn focus_open_window(&self, target: &OpenWindowTarget) -> Result<(), String> {
+        let mut last_error = None;
+        for attempt in 0..4 {
+            let output = Command::new("/usr/bin/osascript")
+                .arg("-e")
+                .arg(focus_open_window_script(target))
+                .output()
+                .map_err(|error| format!("failed to focus window: {error}"))?;
+
+            if output.status.success() {
+                return Ok(());
+            }
+
+            last_error = stderr_or_stdout(&output);
+            if attempt < 3 {
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| "failed to focus window".to_string()))
     }
 
     pub fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String> {
@@ -443,6 +584,173 @@ fn browser_tab_match_score(tab: &BrowserTab, query: &str) -> Option<(u8, u8, usi
     }
 
     None
+}
+
+#[cfg(target_os = "macos")]
+struct CfReleaseGuard(CFTypeRef);
+
+#[cfg(target_os = "macos")]
+impl Drop for CfReleaseGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                CFRelease(self.0);
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn parse_open_window(dictionary: CFDictionaryRef) -> Option<OpenWindow> {
+    let layer = cf_dictionary_i32(dictionary, unsafe { kCGWindowLayer })?;
+    if layer != 0 {
+        return None;
+    }
+
+    let pid = cf_dictionary_i32(dictionary, unsafe { kCGWindowOwnerPID })?;
+    if pid <= 0 {
+        return None;
+    }
+
+    let application = cf_dictionary_string(dictionary, unsafe { kCGWindowOwnerName })?;
+    if application.is_empty() || application == "Rayon" {
+        return None;
+    }
+
+    let title = cf_dictionary_string(dictionary, unsafe { kCGWindowName }).unwrap_or_default();
+    if title.trim().is_empty() {
+        return None;
+    }
+
+    let bounds = cf_dictionary_rect(dictionary, unsafe { kCGWindowBounds })?;
+    let bounds_x = bounds.origin.x.round() as i32;
+    let bounds_y = bounds.origin.y.round() as i32;
+    let bounds_width = bounds.size.width.round() as i32;
+    let bounds_height = bounds.size.height.round() as i32;
+    if bounds_width <= 1 || bounds_height <= 1 {
+        return None;
+    }
+
+    Some(OpenWindow {
+        application,
+        pid,
+        bounds_x,
+        bounds_y,
+        bounds_width,
+        bounds_height,
+        title,
+        is_frontmost: false,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn cf_dictionary_value(dictionary: CFDictionaryRef, key: CFStringRef) -> Option<*const c_void> {
+    let mut value = std::ptr::null();
+    let found = unsafe { CFDictionaryGetValueIfPresent(dictionary, key, &mut value) };
+    if found == 0 || value.is_null() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn cf_dictionary_i32(dictionary: CFDictionaryRef, key: CFStringRef) -> Option<i32> {
+    let value = cf_dictionary_value(dictionary, key)? as CFNumberRef;
+    let mut number = 0_i32;
+    let success = unsafe {
+        CFNumberGetValue(
+            value,
+            K_CF_NUMBER_SINT32_TYPE,
+            (&mut number as *mut i32).cast::<c_void>(),
+        )
+    };
+    if success == 0 {
+        None
+    } else {
+        Some(number)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn cf_dictionary_string(dictionary: CFDictionaryRef, key: CFStringRef) -> Option<String> {
+    let value = cf_dictionary_value(dictionary, key)? as CFStringRef;
+    cf_string_to_string(value)
+}
+
+#[cfg(target_os = "macos")]
+fn cf_dictionary_rect(dictionary: CFDictionaryRef, key: CFStringRef) -> Option<CGRect> {
+    let value = cf_dictionary_value(dictionary, key)? as CFDictionaryRef;
+    let mut rect = CGRect::default();
+    let success = unsafe { CGRectMakeWithDictionaryRepresentation(value, &mut rect) };
+    if success {
+        Some(rect)
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn cf_string_to_string(value: CFStringRef) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+
+    let mut buffer = vec![0_u8; 4096];
+    let success = unsafe {
+        CFStringGetCString(
+            value,
+            buffer.as_mut_ptr().cast::<c_char>(),
+            buffer.len() as isize,
+            K_CF_STRING_ENCODING_UTF8,
+        )
+    };
+    if success == 0 {
+        return None;
+    }
+
+    unsafe { CStr::from_ptr(buffer.as_ptr().cast::<c_char>()) }
+        .to_str()
+        .ok()
+        .map(str::to_string)
+}
+
+fn focus_open_window_script(target: &OpenWindowTarget) -> String {
+    let pid = target.pid;
+    let x = target.bounds_x;
+    let y = target.bounds_y;
+    let width = target.bounds_width;
+    let height = target.bounds_height;
+    let tolerance = OPEN_WINDOW_MATCH_TOLERANCE;
+
+    format!(
+        r#"
+tell application "System Events"
+    if UI elements enabled is false then
+        error "Rayon needs Accessibility access to focus windows"
+    end if
+
+    if not (exists first application process whose unix id is {pid}) then
+        error "Window application is no longer running"
+    end if
+
+    tell first application process whose unix id is {pid}
+        set frontmost to true
+        repeat with w in windows
+            set windowPosition to position of w
+            set windowSize to size of w
+            if (abs((item 1 of windowPosition) - {x}) <= {tolerance}) and (abs((item 2 of windowPosition) - {y}) <= {tolerance}) and (abs((item 1 of windowSize) - {width}) <= {tolerance}) and (abs((item 2 of windowSize) - {height}) <= {tolerance}) then
+                perform action "AXRaise" of w
+                set value of attribute "AXMain" of w to true
+                return "ok"
+            end if
+        end repeat
+    end tell
+end tell
+
+error "Window not found"
+"#
+    )
 }
 
 fn app_path_rank(path: &str) -> usize {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -250,13 +250,14 @@ impl ThemePreference {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum SearchResultKind {
     Command,
     Application,
     Bookmark,
     Image,
     BrowserTab,
+    OpenWindow,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -268,6 +269,7 @@ pub struct ImageAssetDefinition {
 }
 
 pub const BROWSER_TAB_COMMAND_PREFIX: &str = "browser-tab";
+pub const OPEN_WINDOW_COMMAND_PREFIX: &str = "open-window";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserTab {
@@ -330,6 +332,78 @@ pub fn parse_browser_tab_command_id(command_id: &CommandId) -> Option<BrowserTab
         browser: browser.to_string(),
         window_id: window_id.to_string(),
         tab_index,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenWindow {
+    pub application: String,
+    pub pid: i32,
+    pub bounds_x: i32,
+    pub bounds_y: i32,
+    pub bounds_width: i32,
+    pub bounds_height: i32,
+    pub title: String,
+    pub is_frontmost: bool,
+}
+
+impl OpenWindow {
+    pub fn command_id(&self) -> CommandId {
+        CommandId::from(format!(
+            "{OPEN_WINDOW_COMMAND_PREFIX}:{}:{}:{}:{}:{}",
+            self.pid, self.bounds_x, self.bounds_y, self.bounds_width, self.bounds_height
+        ))
+    }
+
+    pub fn display_title(&self) -> String {
+        if self.title.trim().is_empty() {
+            self.application.clone()
+        } else {
+            self.title.clone()
+        }
+    }
+
+    pub fn subtitle(&self) -> String {
+        if self.title.trim().is_empty() {
+            "Open window".into()
+        } else {
+            self.application.clone()
+        }
+    }
+
+    pub fn search_text(&self) -> String {
+        format!("{} {}", self.application, self.title).to_lowercase()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenWindowTarget {
+    pub pid: i32,
+    pub bounds_x: i32,
+    pub bounds_y: i32,
+    pub bounds_width: i32,
+    pub bounds_height: i32,
+}
+
+pub fn parse_open_window_command_id(command_id: &CommandId) -> Option<OpenWindowTarget> {
+    let mut parts = command_id.as_str().split(':');
+    let prefix = parts.next()?;
+    let pid = parts.next()?.parse::<i32>().ok()?;
+    let bounds_x = parts.next()?.parse::<i32>().ok()?;
+    let bounds_y = parts.next()?.parse::<i32>().ok()?;
+    let bounds_width = parts.next()?.parse::<i32>().ok()?;
+    let bounds_height = parts.next()?.parse::<i32>().ok()?;
+
+    if prefix != OPEN_WINDOW_COMMAND_PREFIX || parts.next().is_some() {
+        return None;
+    }
+
+    Some(OpenWindowTarget {
+        pid,
+        bounds_x,
+        bounds_y,
+        bounds_width,
+        bounds_height,
     })
 }
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -339,6 +339,7 @@ pub fn parse_browser_tab_command_id(command_id: &CommandId) -> Option<BrowserTab
 pub struct OpenWindow {
     pub application: String,
     pub pid: i32,
+    pub window_number: i32,
     pub bounds_x: i32,
     pub bounds_y: i32,
     pub bounds_width: i32,
@@ -350,8 +351,13 @@ pub struct OpenWindow {
 impl OpenWindow {
     pub fn command_id(&self) -> CommandId {
         CommandId::from(format!(
-            "{OPEN_WINDOW_COMMAND_PREFIX}:{}:{}:{}:{}:{}",
-            self.pid, self.bounds_x, self.bounds_y, self.bounds_width, self.bounds_height
+            "{OPEN_WINDOW_COMMAND_PREFIX}:{}:{}:{}:{}:{}:{}",
+            self.pid,
+            self.window_number,
+            self.bounds_x,
+            self.bounds_y,
+            self.bounds_width,
+            self.bounds_height
         ))
     }
 
@@ -379,6 +385,7 @@ impl OpenWindow {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpenWindowTarget {
     pub pid: i32,
+    pub window_number: Option<i32>,
     pub bounds_x: i32,
     pub bounds_y: i32,
     pub bounds_width: i32,
@@ -389,22 +396,32 @@ pub fn parse_open_window_command_id(command_id: &CommandId) -> Option<OpenWindow
     let mut parts = command_id.as_str().split(':');
     let prefix = parts.next()?;
     let pid = parts.next()?.parse::<i32>().ok()?;
-    let bounds_x = parts.next()?.parse::<i32>().ok()?;
-    let bounds_y = parts.next()?.parse::<i32>().ok()?;
-    let bounds_width = parts.next()?.parse::<i32>().ok()?;
-    let bounds_height = parts.next()?.parse::<i32>().ok()?;
-
-    if prefix != OPEN_WINDOW_COMMAND_PREFIX || parts.next().is_some() {
+    if prefix != OPEN_WINDOW_COMMAND_PREFIX {
         return None;
     }
 
-    Some(OpenWindowTarget {
-        pid,
-        bounds_x,
-        bounds_y,
-        bounds_width,
-        bounds_height,
-    })
+    let remaining_parts = parts.collect::<Vec<_>>();
+    match remaining_parts.as_slice() {
+        [window_number, bounds_x, bounds_y, bounds_width, bounds_height] => {
+            Some(OpenWindowTarget {
+                pid,
+                window_number: window_number.parse::<i32>().ok(),
+                bounds_x: bounds_x.parse::<i32>().ok()?,
+                bounds_y: bounds_y.parse::<i32>().ok()?,
+                bounds_width: bounds_width.parse::<i32>().ok()?,
+                bounds_height: bounds_height.parse::<i32>().ok()?,
+            })
+        }
+        [bounds_x, bounds_y, bounds_width, bounds_height] => Some(OpenWindowTarget {
+            pid,
+            window_number: None,
+            bounds_x: bounds_x.parse::<i32>().ok()?,
+            bounds_y: bounds_y.parse::<i32>().ok()?,
+            bounds_width: bounds_width.parse::<i32>().ok()?,
+            bounds_height: bounds_height.parse::<i32>().ok()?,
+        }),
+        _ => None,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -463,4 +480,51 @@ pub struct ProcessMatch {
     pub executable_name: String,
     pub command: String,
     pub matched_ports: Vec<u16>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_window_command_id_round_trips_with_window_number() {
+        let window = OpenWindow {
+            application: "Linear".into(),
+            pid: 4242,
+            window_number: 777,
+            bounds_x: 10,
+            bounds_y: 20,
+            bounds_width: 1440,
+            bounds_height: 900,
+            title: "Project Board".into(),
+            is_frontmost: true,
+        };
+
+        assert_eq!(
+            parse_open_window_command_id(&window.command_id()),
+            Some(OpenWindowTarget {
+                pid: 4242,
+                window_number: Some(777),
+                bounds_x: 10,
+                bounds_y: 20,
+                bounds_width: 1440,
+                bounds_height: 900,
+            })
+        );
+    }
+
+    #[test]
+    fn open_window_command_id_still_parses_legacy_format() {
+        assert_eq!(
+            parse_open_window_command_id(&CommandId::from("open-window:4242:10:20:1440:900")),
+            Some(OpenWindowTarget {
+                pid: 4242,
+                window_number: None,
+                bounds_x: 10,
+                bounds_y: 20,
+                bounds_width: 1440,
+                bounds_height: 900,
+            })
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- extend the leading-space search to return both open app windows and browser tabs in one mixed result list
- keep the normal launcher search unchanged while replacing the tab-only special cache with a combined ephemeral index
- add exact window focus routing and window result badges/copy in the desktop UI

## Testing
- cargo test --workspace --quiet
- pnpm --dir apps/desktop test
- pnpm --dir apps/desktop typecheck
- pnpm --dir apps/desktop lint
- cargo clippy --workspace --all-targets -- -D warnings -W clippy::unwrap_used -W clippy::expect_used -W clippy::panic -W clippy::todo -W clippy::dbg_macro
- cargo fmt --all --check

## Notes
- window focus on macOS depends on Accessibility access and matches windows by PID plus bounds

Closes #16