### PR TITLE
Fix packaged leading-space search when one macOS source is denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ Rayon tries to register `Command+Space` as the launcher shortcut. macOS Spotligh
 
 If `Command+Space` is unavailable, Rayon also tries `Command+Shift+Space` as a fallback.
 
+### Permissions On macOS
+
+Rayon can use a few macOS privacy permissions for launcher features that interact with other apps.
+
+- `System Settings > Privacy & Security > Accessibility`
+  Needed to raise and focus another app window.
+- `System Settings > Privacy & Security > Automation`
+  Needed when Rayon is allowed to control apps such as `Google Chrome` or `System Events`.
+- `System Settings > Privacy & Security > Screen & System Audio Recording` or `Screen Recording`
+  On some macOS setups, this may be needed for Rayon to read other apps' window metadata reliably.
+
+If Rayon does not appear in one of these lists, launch the packaged app from `Applications` first. If needed, click `+` in the relevant privacy panel and add `rayon.app` manually.
+
+If leading-space search shows browser tabs but not open windows, check `Accessibility` first. If it shows neither in a packaged build, check both `Automation` and `Screen Recording`.
+
 ## Build From Source
 
 If you want to build Rayon yourself, the repository is set up for a straightforward local workflow.
@@ -83,6 +98,14 @@ pnpm build
 pnpm test
 cargo test --workspace
 ```
+
+For a packaged desktop build, use:
+
+```bash
+pnpm tauri build
+```
+
+`pnpm tauri dev` and `pnpm tauri build` can behave differently on macOS because the packaged app has its own privacy permissions. If a feature works in dev but not in the built `.app`, review the `Accessibility`, `Automation`, and `Screen Recording` settings above for the packaged `rayon.app`.
 
 ## Configuration
 

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSAppleEventsUsageDescription</key>
+  <string>Rayon needs permission to read browser tabs and focus windows across Spaces.</string>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/src/app/state.rs
+++ b/apps/desktop/src-tauri/src/app/state.rs
@@ -203,8 +203,31 @@ impl LeadingSpaceSearchCache {
     }
 
     fn refresh(&mut self, platform: &dyn AppPlatform) -> Result<(), String> {
-        let tabs = platform.search_browser_tabs("")?;
-        let windows = platform.list_open_windows()?;
+        let tabs_result = platform.search_browser_tabs("");
+        let windows_result = platform.list_open_windows();
+        let mut failures = Vec::new();
+
+        let tabs = match tabs_result {
+            Ok(tabs) => tabs,
+            Err(error) => {
+                eprintln!("leading-space browser-tab refresh failed: {error}");
+                failures.push(format!("browser tabs: {error}"));
+                Vec::new()
+            }
+        };
+        let windows = match windows_result {
+            Ok(windows) => windows,
+            Err(error) => {
+                eprintln!("leading-space open-window refresh failed: {error}");
+                failures.push(format!("open windows: {error}"));
+                Vec::new()
+            }
+        };
+
+        if tabs.is_empty() && windows.is_empty() && !failures.is_empty() {
+            return Err(failures.join("; "));
+        }
+
         let ordered_item_ids = windows
             .iter()
             .map(OpenWindow::command_id)
@@ -344,7 +367,9 @@ mod tests {
 
     struct StubPlatform {
         browser_tabs: Mutex<Vec<BrowserTab>>,
+        browser_tabs_error: Mutex<Option<String>>,
         open_windows: Mutex<Vec<OpenWindow>>,
+        open_windows_error: Mutex<Option<String>>,
         search_calls: Mutex<usize>,
     }
 
@@ -367,6 +392,9 @@ mod tests {
 
         fn search_browser_tabs(&self, _query: &str) -> Result<Vec<BrowserTab>, String> {
             *self.search_calls.lock().unwrap() += 1;
+            if let Some(error) = self.browser_tabs_error.lock().unwrap().clone() {
+                return Err(error);
+            }
             Ok(self.browser_tabs.lock().unwrap().clone())
         }
 
@@ -376,6 +404,9 @@ mod tests {
 
         fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
             *self.search_calls.lock().unwrap() += 1;
+            if let Some(error) = self.open_windows_error.lock().unwrap().clone() {
+                return Err(error);
+            }
             Ok(self.open_windows.lock().unwrap().clone())
         }
 
@@ -427,7 +458,9 @@ mod tests {
                 1,
                 1,
             )]),
+            browser_tabs_error: Mutex::new(None),
             open_windows: Mutex::new(vec![sample_window("Rayon", "Arc", 101, true)]),
+            open_windows_error: Mutex::new(None),
             search_calls: Mutex::new(0),
         };
         let mut cache = LeadingSpaceSearchCache::new().unwrap();
@@ -444,7 +477,9 @@ mod tests {
     fn leading_space_search_cache_replaces_stale_items_on_refresh() {
         let platform = StubPlatform {
             browser_tabs: Mutex::new(vec![sample_tab("Old Tab", "https://old.example", 1, 1)]),
+            browser_tabs_error: Mutex::new(None),
             open_windows: Mutex::new(vec![sample_window("Old Window", "Arc", 202, true)]),
+            open_windows_error: Mutex::new(None),
             search_calls: Mutex::new(0),
         };
         let mut cache = LeadingSpaceSearchCache::new().unwrap();
@@ -472,10 +507,12 @@ mod tests {
                 sample_tab("Current", "https://current.example", 1, 1),
                 sample_tab("Other", "https://other.example", 2, 1),
             ]),
+            browser_tabs_error: Mutex::new(None),
             open_windows: Mutex::new(vec![
                 sample_window("Project", "Arc", 404, true),
                 sample_window("Notes", "Obsidian", 505, false),
             ]),
+            open_windows_error: Mutex::new(None),
             search_calls: Mutex::new(0),
         };
         let mut cache = LeadingSpaceSearchCache::new().unwrap();
@@ -504,7 +541,9 @@ mod tests {
                 1,
                 1,
             )]),
+            browser_tabs_error: Mutex::new(None),
             open_windows: Mutex::new(vec![sample_window("Project Board", "Linear", 606, true)]),
+            open_windows_error: Mutex::new(None),
             search_calls: Mutex::new(0),
         };
         let mut cache = LeadingSpaceSearchCache::new().unwrap();
@@ -514,5 +553,64 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].kind, SearchResultKind::OpenWindow);
         assert_eq!(results[1].kind, SearchResultKind::BrowserTab);
+    }
+
+    #[test]
+    fn leading_space_search_keeps_window_results_when_tab_refresh_fails() {
+        let platform = StubPlatform {
+            browser_tabs: Mutex::new(Vec::new()),
+            browser_tabs_error: Mutex::new(Some(
+                "not authorized to send Apple events to Google Chrome".into(),
+            )),
+            open_windows: Mutex::new(vec![sample_window("Project Board", "Linear", 707, true)]),
+            open_windows_error: Mutex::new(None),
+            search_calls: Mutex::new(0),
+        };
+        let mut cache = LeadingSpaceSearchCache::new().unwrap();
+
+        let results = cache.search(&platform, "project", true);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].kind, SearchResultKind::OpenWindow);
+    }
+
+    #[test]
+    fn leading_space_search_keeps_tab_results_when_window_refresh_fails() {
+        let platform = StubPlatform {
+            browser_tabs: Mutex::new(vec![sample_tab(
+                "Project Docs",
+                "https://example.com/docs",
+                1,
+                1,
+            )]),
+            browser_tabs_error: Mutex::new(None),
+            open_windows: Mutex::new(Vec::new()),
+            open_windows_error: Mutex::new(Some("screen recording access denied".into())),
+            search_calls: Mutex::new(0),
+        };
+        let mut cache = LeadingSpaceSearchCache::new().unwrap();
+
+        let results = cache.search(&platform, "project", true);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].kind, SearchResultKind::BrowserTab);
+    }
+
+    #[test]
+    fn leading_space_search_returns_empty_when_all_sources_fail() {
+        let platform = StubPlatform {
+            browser_tabs: Mutex::new(Vec::new()),
+            browser_tabs_error: Mutex::new(Some(
+                "not authorized to send Apple events to Google Chrome".into(),
+            )),
+            open_windows: Mutex::new(Vec::new()),
+            open_windows_error: Mutex::new(Some("screen recording access denied".into())),
+            search_calls: Mutex::new(0),
+        };
+        let mut cache = LeadingSpaceSearchCache::new().unwrap();
+
+        let results = cache.search(&platform, "project", true);
+
+        assert!(results.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- keep leading-space search usable when browser tab lookup or open-window lookup fails independently in packaged macOS builds
- add the macOS Apple Events usage description so the bundled app can request permission for browser-tab automation
- add regression coverage for tabs-only, windows-only, and all-sources-fail refresh paths

## Why
The merged open-windows-across-Spaces feature worked in `pnpm tauri dev`, but the packaged app could fail closed when one permission-gated source errored during refresh. In practice that made leading-space search appear broken in `pnpm tauri build` even when one source was still usable.

## Testing
- `pnpm --dir apps/desktop test -- --runInBand`
- `cargo test -p rayon-desktop leading_space_search --quiet`
- `cargo test --workspace --quiet`
- `pnpm tauri build`