### PR TITLE
Prevent space-search focus targets from bouncing back

### DIFF
--- a/apps/desktop/src-tauri/src/shell.rs
+++ b/apps/desktop/src-tauri/src/shell.rs
@@ -36,17 +36,23 @@ pub fn show_launcher(app: &AppHandle) -> tauri::Result<()> {
 }
 
 pub fn hide_launcher(app: &AppHandle) -> tauri::Result<()> {
+    hide_launcher_window(app)?;
+    clear_previous_frontmost_application();
+    Ok(())
+}
+
+pub fn hide_launcher_and_restore_focus(app: &AppHandle) -> tauri::Result<()> {
+    hide_launcher_window(app)?;
+    restore_previous_frontmost_application();
+    Ok(())
+}
+
+fn hide_launcher_window(app: &AppHandle) -> tauri::Result<()> {
     let window = app
         .get_webview_window(MAIN_WINDOW_LABEL)
         .ok_or_else(|| tauri::Error::AssetNotFound(MAIN_WINDOW_LABEL.into()))?;
 
     window.hide()?;
-    Ok(())
-}
-
-pub fn hide_launcher_and_restore_focus(app: &AppHandle) -> tauri::Result<()> {
-    hide_launcher(app)?;
-    restore_previous_frontmost_application();
     Ok(())
 }
 
@@ -149,6 +155,12 @@ fn store_previous_frontmost_application() {
 #[cfg(not(target_os = "macos"))]
 fn store_previous_frontmost_application() {}
 
+fn clear_previous_frontmost_application() {
+    if let Ok(mut previous_pid) = previous_frontmost_pid().lock() {
+        *previous_pid = None;
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn restore_previous_frontmost_application() {
     let pid = previous_frontmost_pid()
@@ -164,7 +176,9 @@ fn restore_previous_frontmost_application() {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn restore_previous_frontmost_application() {}
+fn restore_previous_frontmost_application() {
+    clear_previous_frontmost_application();
+}
 
 #[cfg(target_os = "macos")]
 unsafe fn frontmost_application_pid() -> Option<i32> {
@@ -210,4 +224,42 @@ unsafe fn activate_application(pid: i32) -> bool {
     let options = NS_APPLICATION_ACTIVATE_ALL_WINDOWS | NS_APPLICATION_ACTIVATE_IGNORING_OTHER_APPS;
     let activated: BOOL = msg_send![running_application, activateWithOptions: options];
     activated == YES
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn lock_previous_frontmost_pid() -> std::sync::MutexGuard<'static, Option<i32>> {
+        previous_frontmost_pid()
+            .lock()
+            .expect("previous frontmost pid mutex should not be poisoned")
+    }
+
+    #[test]
+    fn clear_previous_frontmost_application_resets_stored_pid() {
+        {
+            let mut previous_pid = lock_previous_frontmost_pid();
+            *previous_pid = Some(4242);
+        }
+
+        clear_previous_frontmost_application();
+
+        let previous_pid = lock_previous_frontmost_pid();
+        assert_eq!(*previous_pid, None);
+    }
+
+    #[test]
+    fn restore_previous_frontmost_application_consumes_stored_pid() {
+        {
+            let mut previous_pid = lock_previous_frontmost_pid();
+            *previous_pid = Some(-1);
+        }
+
+        restore_previous_frontmost_application();
+
+        let previous_pid = lock_previous_frontmost_pid();
+        assert_eq!(*previous_pid, None);
+    }
 }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -277,6 +277,70 @@ describe("App", () => {
     expect(input.getAttribute("placeholder")).toBe("Search open windows and tabs");
   });
 
+  it("hides the launcher without restoring focus after selecting a browser tab", async () => {
+    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
+      searchResult({
+        id: "browser-tab:chrome:window-1:1",
+        title: "Issue 15",
+        subtitle: "github.com",
+        kind: "browser_tab",
+        close_launcher_on_success: true,
+      }),
+    ]);
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: " issue" } });
+
+    expect(await screen.findByText("Issue 15")).toBeTruthy();
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(launcherApi.executeLauncherCommand).toHaveBeenCalledWith(
+        "browser-tab:chrome:window-1:1",
+        {},
+        [],
+      );
+    });
+    await waitFor(() => {
+      expect(launcherApi.hideLauncher).toHaveBeenCalled();
+    });
+    expect(launcherApi.hideLauncherAndRestoreFocus).not.toHaveBeenCalled();
+  });
+
+  it("hides the launcher without restoring focus after selecting an open window", async () => {
+    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
+      searchResult({
+        id: "open-window:4242:777:10:20:1440:900",
+        title: "Project Board",
+        subtitle: "Linear",
+        kind: "open_window",
+        close_launcher_on_success: true,
+      }),
+    ]);
+
+    render(<App />);
+
+    const input = screen.getByLabelText("Command search");
+    fireEvent.change(input, { target: { value: " project" } });
+
+    expect(await screen.findByText("Project Board")).toBeTruthy();
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(launcherApi.executeLauncherCommand).toHaveBeenCalledWith(
+        "open-window:4242:777:10:20:1440:900",
+        {},
+        [],
+      );
+    });
+    await waitFor(() => {
+      expect(launcherApi.hideLauncher).toHaveBeenCalled();
+    });
+    expect(launcherApi.hideLauncherAndRestoreFocus).not.toHaveBeenCalled();
+  });
+
   it("refreshes browser tabs only when entering tab mode", async () => {
     vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
       searchResult({

--- a/apps/desktop/src/features/launcher/useLauncherController.ts
+++ b/apps/desktop/src/features/launcher/useLauncherController.ts
@@ -251,6 +251,7 @@ export function useLauncherController(): LauncherController {
     argumentsMap: Record<string, CommandArgumentValue>,
     argv: string[] = [],
     closeLauncherOnSuccess = false,
+    restoreFocusOnSuccess = closeLauncherOnSuccess,
     optimisticSessionId?: string,
   ) {
     try {
@@ -276,7 +277,11 @@ export function useLauncherController(): LauncherController {
         void refreshThemePreference();
 
         try {
-          await hideLauncherAndRestoreFocus();
+          if (restoreFocusOnSuccess) {
+            await hideLauncherAndRestoreFocus();
+          } else {
+            await hideLauncher();
+          }
           resetLauncher();
         } catch (hideError) {
           setError(hideError instanceof Error ? hideError.message : String(hideError));
@@ -355,13 +360,20 @@ export function useLauncherController(): LauncherController {
           {},
           inlineExecution.argv,
           false,
+          false,
           optimisticSession.session_id,
         );
       });
       return;
     }
 
-    await executeCommand(result.id, {}, inlineExecution.argv, result.close_launcher_on_success);
+    await executeCommand(
+      result.id,
+      {},
+      inlineExecution.argv,
+      result.close_launcher_on_success,
+      shouldRestoreFocusAfterSuccess(result),
+    );
   }
 
   async function executeSelectedCommand() {
@@ -471,6 +483,7 @@ export function useLauncherController(): LauncherController {
       step.argumentsMap,
       [],
       activePendingExecution.closeLauncherOnSuccess,
+      true,
     );
   }
 
@@ -765,6 +778,10 @@ function getLauncherInputMode(query: string): LauncherInputMode {
 
 function normalizeBrowserTabQuery(query: string): string {
   return query.slice(1).trim();
+}
+
+function shouldRestoreFocusAfterSuccess(result: SearchResult): boolean {
+  return result.kind !== "browser_tab" && result.kind !== "open_window";
 }
 
 async function resolveLauncherSearch(query: string): Promise<{

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -167,14 +167,6 @@ impl MacOsAppManager {
             return Err(format!("unsupported browser target: {}", target.browser));
         }
 
-        let status = Command::new("/usr/bin/open")
-            .args(["-a", "Google Chrome"])
-            .status()
-            .map_err(|error| format!("failed to activate Google Chrome: {error}"))?;
-        if !status.success() {
-            return Err("failed to activate Google Chrome".to_string());
-        }
-
         let mut last_error = None;
         for attempt in 0..4 {
             let output = Command::new("/usr/bin/osascript")
@@ -738,14 +730,7 @@ tell application "System Events"
     end if
 
     set targetProcess to first application process whose unix id is {pid}
-    set targetAppName to name of targetProcess
 end tell
-
-tell application targetAppName
-    activate
-end tell
-
-delay 0.05
 
 tell application "System Events"
     tell first application process whose unix id is {pid}
@@ -1165,9 +1150,19 @@ mod tests {
             bounds_height: 900,
         });
 
-        assert!(script.contains("tell application targetAppName"));
-        assert!(script.contains("activate"));
+        assert!(script.contains("set frontmost to true"));
         assert!(script.contains("AXWindowNumber"));
         assert!(script.contains("is 777"));
+        assert!(!script.contains("tell application targetAppName"));
+        assert!(!script.contains("\n    activate\n"));
+    }
+
+    #[test]
+    fn chrome_focus_tab_script_uses_single_activation_path() {
+        let script = chrome_focus_tab_script("window-1", 2);
+
+        assert!(script.contains("set active tab index of targetWindow to 2"));
+        assert!(script.contains("\n    activate\n"));
+        assert!(!script.contains("/usr/bin/open"));
     }
 }


### PR DESCRIPTION
## Summary
- stop leading-space browser tab selections from restoring the previously focused app
- stop leading-space open window selections from restoring the previously focused app
- keep restore-focus behavior unchanged for other auto-close command and interactive flows

## Testing
- pnpm --dir apps/desktop test -- App.test.tsx
- pnpm --dir apps/desktop lint
- pnpm --dir apps/desktop typecheck
- pre-push hooks: frontend-tests and rust-tests