### PR TITLE
Remove open-window leading-space search

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,12 @@ If `Command+Space` is unavailable, Rayon also tries `Command+Shift+Space` as a f
 
 ### Permissions On macOS
 
-Rayon can use a few macOS privacy permissions for launcher features that interact with other apps.
+Rayon can use macOS privacy permissions for launcher features that interact with other apps.
 
-- `System Settings > Privacy & Security > Accessibility`
-  Needed to raise and focus another app window.
 - `System Settings > Privacy & Security > Automation`
   Needed when Rayon is allowed to control apps such as `Google Chrome` or `System Events`.
-- `System Settings > Privacy & Security > Screen & System Audio Recording` or `Screen Recording`
-  On some macOS setups, this may be needed for Rayon to read other apps' window metadata reliably.
 
 If Rayon does not appear in one of these lists, launch the packaged app from `Applications` first. If needed, click `+` in the relevant privacy panel and add `rayon.app` manually.
-
-If leading-space search shows browser tabs but not open windows, check `Accessibility` first. If it shows neither in a packaged build, check both `Automation` and `Screen Recording`.
 
 ## Build From Source
 
@@ -105,7 +99,7 @@ For a packaged desktop build, use:
 pnpm tauri build
 ```
 
-`pnpm tauri dev` and `pnpm tauri build` can behave differently on macOS because the packaged app has its own privacy permissions. If a feature works in dev but not in the built `.app`, review the `Accessibility`, `Automation`, and `Screen Recording` settings above for the packaged `rayon.app`.
+`pnpm tauri dev` and `pnpm tauri build` can behave differently on macOS because the packaged app has its own privacy permissions. If a feature works in dev but not in the built `.app`, review the `Automation` settings above for the packaged `rayon.app`.
 
 ## Configuration
 

--- a/apps/desktop/src-tauri/src/app/adapters.rs
+++ b/apps/desktop/src-tauri/src/app/adapters.rs
@@ -2,8 +2,7 @@ use rayon_core::{AppPlatform, SearchIndex, SearchIndexStats};
 use rayon_db::TantivySearchIndex;
 use rayon_platform::MacOsAppManager;
 use rayon_types::{
-    BrowserTab, BrowserTabTarget, InstalledApp, OpenWindow, OpenWindowTarget, ProcessMatch,
-    SearchableItemDocument,
+    BrowserTab, BrowserTabTarget, InstalledApp, ProcessMatch, SearchableItemDocument,
 };
 
 pub(super) struct DesktopPlatform {
@@ -41,14 +40,6 @@ impl AppPlatform for DesktopPlatform {
 
     fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String> {
         self.inner.focus_browser_tab(target)
-    }
-
-    fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
-        self.inner.list_open_windows()
-    }
-
-    fn focus_open_window(&self, target: &OpenWindowTarget) -> Result<(), String> {
-        self.inner.focus_open_window(target)
     }
 
     fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String> {

--- a/apps/desktop/src-tauri/src/app/launcher.rs
+++ b/apps/desktop/src-tauri/src/app/launcher.rs
@@ -165,14 +165,6 @@ mod tests {
             Ok(())
         }
 
-        fn list_open_windows(&self) -> Result<Vec<rayon_types::OpenWindow>, String> {
-            Ok(Vec::new())
-        }
-
-        fn focus_open_window(&self, _target: &rayon_types::OpenWindowTarget) -> Result<(), String> {
-            Ok(())
-        }
-
         fn search_processes(&self, _query: &str) -> Result<Vec<ProcessMatch>, String> {
             Ok(Vec::new())
         }

--- a/apps/desktop/src-tauri/src/app/state.rs
+++ b/apps/desktop/src-tauri/src/app/state.rs
@@ -4,14 +4,13 @@ use rayon_features::{ClipboardHistoryService, ThemeSettingsStore};
 use rayon_types::{
     BrowserTab, CommandExecutionRequest, CommandExecutionResult, CommandInvocationResult,
     InteractiveSessionQueryRequest, InteractiveSessionState, InteractiveSessionSubmitRequest,
-    InteractiveSessionSubmitResult, OpenWindow, SearchResult, SearchResultKind,
-    SearchableItemDocument,
+    InteractiveSessionSubmitResult, SearchResult, SearchResultKind, SearchableItemDocument,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tauri::AppHandle;
 
-const LEADING_SPACE_SEARCH_LIMIT: usize = 20;
+const BROWSER_TAB_SEARCH_LIMIT: usize = 20;
 
 pub struct AppState {
     launcher: RwLock<LauncherService>,
@@ -19,7 +18,7 @@ pub struct AppState {
     search_index: Arc<dyn SearchIndex>,
     clipboard_history: Arc<ClipboardHistoryService>,
     theme_settings: Arc<ThemeSettingsStore>,
-    leading_space_search_cache: Mutex<LeadingSpaceSearchCache>,
+    browser_tab_search_cache: Mutex<BrowserTabSearchCache>,
 }
 
 impl AppState {
@@ -50,7 +49,7 @@ impl AppState {
             search_index: app_index,
             clipboard_history,
             theme_settings,
-            leading_space_search_cache: Mutex::new(LeadingSpaceSearchCache::new()?),
+            browser_tab_search_cache: Mutex::new(BrowserTabSearchCache::new()?),
         })
     }
 
@@ -69,10 +68,10 @@ impl AppState {
     }
 
     pub fn search_browser_tabs(&self, query: &str, refresh: bool) -> Vec<SearchResult> {
-        match self.leading_space_search_cache.lock() {
+        match self.browser_tab_search_cache.lock() {
             Ok(mut cache) => cache.search(self.platform.as_ref(), query, refresh),
             Err(poisoned) => {
-                eprintln!("leading-space search cache lock poisoned");
+                eprintln!("browser tab search cache lock poisoned");
                 poisoned
                     .into_inner()
                     .search(self.platform.as_ref(), query, refresh)
@@ -136,18 +135,18 @@ impl AppState {
     }
 }
 
-struct LeadingSpaceSearchCache {
-    items_by_id: HashMap<String, LeadingSpaceItem>,
-    ordered_item_ids: Vec<String>,
+struct BrowserTabSearchCache {
+    tabs_by_id: HashMap<String, BrowserTab>,
+    ordered_tab_ids: Vec<String>,
     search_index: rayon_db::TantivySearchIndex,
     initialized: bool,
 }
 
-impl LeadingSpaceSearchCache {
+impl BrowserTabSearchCache {
     fn new() -> Result<Self, String> {
         Ok(Self {
-            items_by_id: HashMap::new(),
-            ordered_item_ids: Vec::new(),
+            tabs_by_id: HashMap::new(),
+            ordered_tab_ids: Vec::new(),
             search_index: rayon_db::TantivySearchIndex::create_in_memory()
                 .map_err(|error| error.to_string())?,
             initialized: false,
@@ -162,7 +161,7 @@ impl LeadingSpaceSearchCache {
     ) -> Vec<SearchResult> {
         if refresh || !self.initialized {
             if let Err(error) = self.refresh(platform) {
-                eprintln!("leading-space refresh failed: {error}");
+                eprintln!("browser tab refresh failed: {error}");
                 return Vec::new();
             }
         }
@@ -170,179 +169,80 @@ impl LeadingSpaceSearchCache {
         let normalized_query = query.trim();
         if normalized_query.is_empty() {
             return self
-                .ordered_item_ids
+                .ordered_tab_ids
                 .iter()
-                .take(LEADING_SPACE_SEARCH_LIMIT)
-                .filter_map(|item_id| self.items_by_id.get(item_id))
-                .map(LeadingSpaceItem::search_result)
+                .take(BROWSER_TAB_SEARCH_LIMIT)
+                .filter_map(|tab_id| self.tabs_by_id.get(tab_id))
+                .cloned()
+                .map(browser_tab_search_result)
                 .collect();
         }
 
         let item_ids = match self
             .search_index
-            .search_item_ids(normalized_query, LEADING_SPACE_SEARCH_LIMIT)
+            .search_item_ids(normalized_query, BROWSER_TAB_SEARCH_LIMIT)
         {
             Ok(item_ids) => item_ids,
             Err(error) => {
-                eprintln!("leading-space index search failed: {error}");
+                eprintln!("browser tab index search failed: {error}");
                 return Vec::new();
             }
         };
 
-        let mut matches = item_ids
+        item_ids
             .into_iter()
-            .enumerate()
-            .filter_map(|(index, item_id)| {
-                self.items_by_id
-                    .get(&item_id)
-                    .map(|item| (leading_space_sort_key(item, index), item.search_result()))
-            })
-            .collect::<Vec<_>>();
-        matches.sort_by(|left, right| left.0.cmp(&right.0));
-        matches.into_iter().map(|(_, result)| result).collect()
+            .filter_map(|item_id| self.tabs_by_id.get(&item_id))
+            .cloned()
+            .map(browser_tab_search_result)
+            .collect()
     }
 
     fn refresh(&mut self, platform: &dyn AppPlatform) -> Result<(), String> {
-        let tabs_result = platform.search_browser_tabs("");
-        let windows_result = platform.list_open_windows();
-        let mut failures = Vec::new();
-
-        let tabs = match tabs_result {
-            Ok(tabs) => tabs,
-            Err(error) => {
-                eprintln!("leading-space browser-tab refresh failed: {error}");
-                failures.push(format!("browser tabs: {error}"));
-                Vec::new()
-            }
-        };
-        let windows = match windows_result {
-            Ok(windows) => windows,
-            Err(error) => {
-                eprintln!("leading-space open-window refresh failed: {error}");
-                failures.push(format!("open windows: {error}"));
-                Vec::new()
-            }
-        };
-
-        if tabs.is_empty() && windows.is_empty() && !failures.is_empty() {
-            return Err(failures.join("; "));
-        }
-
-        let ordered_item_ids = windows
+        let tabs = platform.search_browser_tabs("")?;
+        let documents = tabs
             .iter()
-            .map(OpenWindow::command_id)
-            .chain(tabs.iter().map(BrowserTab::command_id))
-            .map(|id| id.to_string())
+            .map(|tab| SearchableItemDocument {
+                id: tab.command_id(),
+                kind: SearchResultKind::BrowserTab,
+                title: tab.title.clone(),
+                subtitle: Some(tab.subtitle()),
+                owner_plugin_id: None,
+                search_text: tab.search_text(),
+            })
             .collect::<Vec<_>>();
-
-        let mut documents = windows
-            .iter()
-            .map(LeadingSpaceItem::window_search_document)
-            .collect::<Vec<_>>();
-        documents.extend(
-            tabs.iter()
-                .map(LeadingSpaceItem::tab_search_document)
-                .collect::<Vec<_>>(),
-        );
 
         self.search_index
             .replace_items(&documents)
             .map_err(|error| error.to_string())?;
 
-        self.items_by_id = windows
-            .into_iter()
-            .map(|window| {
-                let item = LeadingSpaceItem::OpenWindow(window);
-                (item.id().to_string(), item)
-            })
-            .chain(tabs.into_iter().map(|tab| {
-                let item = LeadingSpaceItem::BrowserTab(tab);
-                (item.id().to_string(), item)
-            }))
+        self.tabs_by_id = tabs
+            .iter()
+            .cloned()
+            .map(|tab| (tab.command_id().to_string(), tab))
             .collect();
-
-        self.ordered_item_ids = ordered_item_ids;
+        self.ordered_tab_ids = tabs
+            .into_iter()
+            .map(|tab| tab.command_id().to_string())
+            .collect();
         self.initialized = true;
         Ok(())
     }
 }
 
-#[derive(Clone)]
-enum LeadingSpaceItem {
-    BrowserTab(BrowserTab),
-    OpenWindow(OpenWindow),
-}
-
-impl LeadingSpaceItem {
-    fn id(&self) -> rayon_types::CommandId {
-        match self {
-            Self::BrowserTab(tab) => tab.command_id(),
-            Self::OpenWindow(window) => window.command_id(),
-        }
-    }
-
-    fn search_result(&self) -> SearchResult {
-        match self {
-            Self::BrowserTab(tab) => SearchResult {
-                id: tab.command_id(),
-                title: tab.title.clone(),
-                subtitle: Some(tab.subtitle()),
-                icon_path: None,
-                kind: SearchResultKind::BrowserTab,
-                owner_plugin_id: None,
-                keywords: Vec::new(),
-                starts_interactive_session: false,
-                close_launcher_on_success: true,
-                input_mode: rayon_types::CommandInputMode::Structured,
-                arguments: Vec::new(),
-            },
-            Self::OpenWindow(window) => SearchResult {
-                id: window.command_id(),
-                title: window.display_title(),
-                subtitle: Some(window.subtitle()),
-                icon_path: None,
-                kind: SearchResultKind::OpenWindow,
-                owner_plugin_id: None,
-                keywords: Vec::new(),
-                starts_interactive_session: false,
-                close_launcher_on_success: true,
-                input_mode: rayon_types::CommandInputMode::Structured,
-                arguments: Vec::new(),
-            },
-        }
-    }
-
-    fn tab_search_document(tab: &BrowserTab) -> SearchableItemDocument {
-        SearchableItemDocument {
-            id: tab.command_id(),
-            kind: SearchResultKind::BrowserTab,
-            title: tab.title.clone(),
-            subtitle: Some(tab.subtitle()),
-            owner_plugin_id: None,
-            search_text: tab.search_text(),
-        }
-    }
-
-    fn window_search_document(window: &OpenWindow) -> SearchableItemDocument {
-        SearchableItemDocument {
-            id: window.command_id(),
-            kind: SearchResultKind::OpenWindow,
-            title: window.display_title(),
-            subtitle: Some(window.subtitle()),
-            owner_plugin_id: None,
-            search_text: window.search_text(),
-        }
-    }
-}
-
-fn leading_space_sort_key(item: &LeadingSpaceItem, original_index: usize) -> (u8, u8, usize) {
-    match item {
-        LeadingSpaceItem::OpenWindow(window) => {
-            (0, if window.is_frontmost { 0 } else { 1 }, original_index)
-        }
-        LeadingSpaceItem::BrowserTab(tab) => {
-            (1, if tab.is_active() { 0 } else { 1 }, original_index)
-        }
+fn browser_tab_search_result(tab: BrowserTab) -> SearchResult {
+    let subtitle = tab.subtitle();
+    SearchResult {
+        id: tab.command_id(),
+        title: tab.title,
+        subtitle: Some(subtitle),
+        icon_path: None,
+        kind: SearchResultKind::BrowserTab,
+        owner_plugin_id: None,
+        keywords: Vec::new(),
+        starts_interactive_session: false,
+        close_launcher_on_success: true,
+        input_mode: rayon_types::CommandInputMode::Structured,
+        arguments: Vec::new(),
     }
 }
 
@@ -360,16 +260,11 @@ pub fn write_launcher(launcher: &RwLock<LauncherService>) -> RwLockWriteGuard<'_
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use rayon_types::{
-        BrowserTabTarget, CommandId, InstalledApp, OpenWindow, OpenWindowTarget, ProcessMatch,
-    };
+    use rayon_types::{BrowserTabTarget, CommandId, InstalledApp, ProcessMatch};
     use std::sync::Mutex;
 
     struct StubPlatform {
         browser_tabs: Mutex<Vec<BrowserTab>>,
-        browser_tabs_error: Mutex<Option<String>>,
-        open_windows: Mutex<Vec<OpenWindow>>,
-        open_windows_error: Mutex<Option<String>>,
         search_calls: Mutex<usize>,
     }
 
@@ -392,25 +287,10 @@ mod tests {
 
         fn search_browser_tabs(&self, _query: &str) -> Result<Vec<BrowserTab>, String> {
             *self.search_calls.lock().unwrap() += 1;
-            if let Some(error) = self.browser_tabs_error.lock().unwrap().clone() {
-                return Err(error);
-            }
             Ok(self.browser_tabs.lock().unwrap().clone())
         }
 
         fn focus_browser_tab(&self, _target: &BrowserTabTarget) -> Result<(), String> {
-            Ok(())
-        }
-
-        fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
-            *self.search_calls.lock().unwrap() += 1;
-            if let Some(error) = self.open_windows_error.lock().unwrap().clone() {
-                return Err(error);
-            }
-            Ok(self.open_windows.lock().unwrap().clone())
-        }
-
-        fn focus_open_window(&self, _target: &OpenWindowTarget) -> Result<(), String> {
             Ok(())
         }
 
@@ -435,22 +315,8 @@ mod tests {
         }
     }
 
-    fn sample_window(title: &str, application: &str, pid: i32, frontmost: bool) -> OpenWindow {
-        OpenWindow {
-            application: application.into(),
-            pid,
-            window_number: pid * 100,
-            bounds_x: pid * 10,
-            bounds_y: pid * 10,
-            bounds_width: 1440,
-            bounds_height: 900,
-            title: title.into(),
-            is_frontmost: frontmost,
-        }
-    }
-
     #[test]
-    fn leading_space_search_cache_refreshes_only_on_request() {
+    fn browser_tab_search_cache_refreshes_only_on_request() {
         let platform = StubPlatform {
             browser_tabs: Mutex::new(vec![sample_tab(
                 "Issue 15",
@@ -458,82 +324,66 @@ mod tests {
                 1,
                 1,
             )]),
-            browser_tabs_error: Mutex::new(None),
-            open_windows: Mutex::new(vec![sample_window("Rayon", "Arc", 101, true)]),
-            open_windows_error: Mutex::new(None),
             search_calls: Mutex::new(0),
         };
-        let mut cache = LeadingSpaceSearchCache::new().unwrap();
+        let mut cache = BrowserTabSearchCache::new().unwrap();
 
         let first_results = cache.search(&platform, "issue", true);
         let second_results = cache.search(&platform, "rayon", false);
 
         assert_eq!(first_results.len(), 1);
-        assert_eq!(second_results.len(), 2);
-        assert_eq!(*platform.search_calls.lock().unwrap(), 2);
+        assert_eq!(second_results.len(), 1);
+        assert_eq!(*platform.search_calls.lock().unwrap(), 1);
     }
 
     #[test]
-    fn leading_space_search_cache_replaces_stale_items_on_refresh() {
+    fn browser_tab_search_cache_replaces_stale_tabs_on_refresh() {
         let platform = StubPlatform {
             browser_tabs: Mutex::new(vec![sample_tab("Old Tab", "https://old.example", 1, 1)]),
-            browser_tabs_error: Mutex::new(None),
-            open_windows: Mutex::new(vec![sample_window("Old Window", "Arc", 202, true)]),
-            open_windows_error: Mutex::new(None),
             search_calls: Mutex::new(0),
         };
-        let mut cache = LeadingSpaceSearchCache::new().unwrap();
+        let mut cache = BrowserTabSearchCache::new().unwrap();
 
         let old_results = cache.search(&platform, "old", true);
-        assert_eq!(old_results.len(), 2);
+        assert_eq!(old_results[0].title, "Old Tab");
 
         *platform.browser_tabs.lock().unwrap() =
             vec![sample_tab("Fresh Tab", "https://fresh.example/path", 1, 1)];
-        *platform.open_windows.lock().unwrap() =
-            vec![sample_window("Fresh Window", "Finder", 303, true)];
 
         let stale_results = cache.search(&platform, "fresh", false);
         assert!(stale_results.is_empty());
 
         let fresh_results = cache.search(&platform, "fresh", true);
-        assert_eq!(fresh_results.len(), 2);
-        assert_eq!(*platform.search_calls.lock().unwrap(), 4);
+        assert_eq!(fresh_results[0].title, "Fresh Tab");
+        assert_eq!(*platform.search_calls.lock().unwrap(), 2);
     }
 
     #[test]
-    fn leading_space_search_cache_returns_windows_then_tabs_for_blank_query() {
+    fn browser_tab_search_cache_returns_all_tabs_for_blank_query() {
         let platform = StubPlatform {
             browser_tabs: Mutex::new(vec![
                 sample_tab("Current", "https://current.example", 1, 1),
                 sample_tab("Other", "https://other.example", 2, 1),
             ]),
-            browser_tabs_error: Mutex::new(None),
-            open_windows: Mutex::new(vec![
-                sample_window("Project", "Arc", 404, true),
-                sample_window("Notes", "Obsidian", 505, false),
-            ]),
-            open_windows_error: Mutex::new(None),
             search_calls: Mutex::new(0),
         };
-        let mut cache = LeadingSpaceSearchCache::new().unwrap();
+        let mut cache = BrowserTabSearchCache::new().unwrap();
 
         let results = cache.search(&platform, "", true);
 
-        assert_eq!(results.len(), 4);
-        assert_eq!(results[0].kind, SearchResultKind::OpenWindow);
+        assert_eq!(results.len(), 2);
         assert_eq!(
             results[0].id,
-            CommandId::from("open-window:404:40400:4040:4040:1440:900")
-        );
-        assert_eq!(results[2].kind, SearchResultKind::BrowserTab);
-        assert_eq!(
-            results[2].id,
             CommandId::from("browser-tab:chrome:window-1:1")
         );
+        assert_eq!(
+            results[1].id,
+            CommandId::from("browser-tab:chrome:window-2:1")
+        );
     }
 
     #[test]
-    fn leading_space_search_prioritizes_windows_over_tabs_for_matching_queries() {
+    fn browser_tab_search_cache_matches_queries() {
         let platform = StubPlatform {
             browser_tabs: Mutex::new(vec![sample_tab(
                 "Project Docs",
@@ -541,76 +391,13 @@ mod tests {
                 1,
                 1,
             )]),
-            browser_tabs_error: Mutex::new(None),
-            open_windows: Mutex::new(vec![sample_window("Project Board", "Linear", 606, true)]),
-            open_windows_error: Mutex::new(None),
             search_calls: Mutex::new(0),
         };
-        let mut cache = LeadingSpaceSearchCache::new().unwrap();
-
-        let results = cache.search(&platform, "project", true);
-
-        assert_eq!(results.len(), 2);
-        assert_eq!(results[0].kind, SearchResultKind::OpenWindow);
-        assert_eq!(results[1].kind, SearchResultKind::BrowserTab);
-    }
-
-    #[test]
-    fn leading_space_search_keeps_window_results_when_tab_refresh_fails() {
-        let platform = StubPlatform {
-            browser_tabs: Mutex::new(Vec::new()),
-            browser_tabs_error: Mutex::new(Some(
-                "not authorized to send Apple events to Google Chrome".into(),
-            )),
-            open_windows: Mutex::new(vec![sample_window("Project Board", "Linear", 707, true)]),
-            open_windows_error: Mutex::new(None),
-            search_calls: Mutex::new(0),
-        };
-        let mut cache = LeadingSpaceSearchCache::new().unwrap();
-
-        let results = cache.search(&platform, "project", true);
-
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].kind, SearchResultKind::OpenWindow);
-    }
-
-    #[test]
-    fn leading_space_search_keeps_tab_results_when_window_refresh_fails() {
-        let platform = StubPlatform {
-            browser_tabs: Mutex::new(vec![sample_tab(
-                "Project Docs",
-                "https://example.com/docs",
-                1,
-                1,
-            )]),
-            browser_tabs_error: Mutex::new(None),
-            open_windows: Mutex::new(Vec::new()),
-            open_windows_error: Mutex::new(Some("screen recording access denied".into())),
-            search_calls: Mutex::new(0),
-        };
-        let mut cache = LeadingSpaceSearchCache::new().unwrap();
+        let mut cache = BrowserTabSearchCache::new().unwrap();
 
         let results = cache.search(&platform, "project", true);
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].kind, SearchResultKind::BrowserTab);
-    }
-
-    #[test]
-    fn leading_space_search_returns_empty_when_all_sources_fail() {
-        let platform = StubPlatform {
-            browser_tabs: Mutex::new(Vec::new()),
-            browser_tabs_error: Mutex::new(Some(
-                "not authorized to send Apple events to Google Chrome".into(),
-            )),
-            open_windows: Mutex::new(Vec::new()),
-            open_windows_error: Mutex::new(Some("screen recording access denied".into())),
-            search_calls: Mutex::new(0),
-        };
-        let mut cache = LeadingSpaceSearchCache::new().unwrap();
-
-        let results = cache.search(&platform, "project", true);
-
-        assert!(results.is_empty());
     }
 }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -212,7 +212,7 @@ describe("App", () => {
     expect(await screen.findByText("Issue 15")).toBeTruthy();
     expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("issue", true);
     expect(launcherApi.searchLauncher).not.toHaveBeenCalled();
-    expect(input.getAttribute("placeholder")).toBe("Search open windows and tabs");
+    expect(input.getAttribute("placeholder")).toBe("Search open Chrome tabs");
     expect(input.getAttribute("data-mode")).toBe("browser_tabs");
   });
 
@@ -236,26 +236,6 @@ describe("App", () => {
     expect(await screen.findByText("Image")).toBeTruthy();
   });
 
-  it("renders leading-space window results with the window badge", async () => {
-    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
-      searchResult({
-        id: "open-window:4242:777:10:20:1440:900",
-        title: "Project Board",
-        subtitle: "Linear",
-        kind: "open_window",
-        close_launcher_on_success: true,
-      }),
-    ]);
-
-    render(<App />);
-
-    const input = screen.getByLabelText("Command search");
-    fireEvent.change(input, { target: { value: " project" } });
-
-    expect(await screen.findByText("Project Board")).toBeTruthy();
-    expect(await screen.findByText("Window")).toBeTruthy();
-  });
-
   it("shows all tabs when the query is only a leading space", async () => {
     vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
       searchResult({
@@ -274,7 +254,7 @@ describe("App", () => {
 
     expect(await screen.findByText("Rayon")).toBeTruthy();
     expect(launcherApi.searchBrowserTabs).toHaveBeenCalledWith("", true);
-    expect(input.getAttribute("placeholder")).toBe("Search open windows and tabs");
+    expect(input.getAttribute("placeholder")).toBe("Search open Chrome tabs");
   });
 
   it("hides the launcher without restoring focus after selecting a browser tab", async () => {
@@ -299,38 +279,6 @@ describe("App", () => {
     await waitFor(() => {
       expect(launcherApi.executeLauncherCommand).toHaveBeenCalledWith(
         "browser-tab:chrome:window-1:1",
-        {},
-        [],
-      );
-    });
-    await waitFor(() => {
-      expect(launcherApi.hideLauncher).toHaveBeenCalled();
-    });
-    expect(launcherApi.hideLauncherAndRestoreFocus).not.toHaveBeenCalled();
-  });
-
-  it("hides the launcher without restoring focus after selecting an open window", async () => {
-    vi.mocked(launcherApi.searchBrowserTabs).mockResolvedValue([
-      searchResult({
-        id: "open-window:4242:777:10:20:1440:900",
-        title: "Project Board",
-        subtitle: "Linear",
-        kind: "open_window",
-        close_launcher_on_success: true,
-      }),
-    ]);
-
-    render(<App />);
-
-    const input = screen.getByLabelText("Command search");
-    fireEvent.change(input, { target: { value: " project" } });
-
-    expect(await screen.findByText("Project Board")).toBeTruthy();
-    await userEvent.keyboard("{Enter}");
-
-    await waitFor(() => {
-      expect(launcherApi.executeLauncherCommand).toHaveBeenCalledWith(
-        "open-window:4242:777:10:20:1440:900",
         {},
         [],
       );

--- a/apps/desktop/src/commandExecution.ts
+++ b/apps/desktop/src/commandExecution.ts
@@ -16,7 +16,7 @@ export type SearchResult = {
   title: string;
   subtitle: string | null;
   icon_path: string | null;
-  kind: "command" | "application" | "bookmark" | "image" | "browser_tab" | "open_window";
+  kind: "command" | "application" | "bookmark" | "image" | "browser_tab";
   owner_plugin_id: string | null;
   keywords: string[];
   starts_interactive_session: boolean;

--- a/apps/desktop/src/features/launcher/copy.ts
+++ b/apps/desktop/src/features/launcher/copy.ts
@@ -40,9 +40,6 @@ export function getInteractiveSubmitHint(session: InteractiveSessionState): stri
 }
 
 export function getSearchResultKind(result: SearchResult): string {
-  if (result.kind === "open_window") {
-    return "Window";
-  }
   if (result.kind === "browser_tab") {
     return "Tab";
   }

--- a/apps/desktop/src/features/launcher/useLauncherController.ts
+++ b/apps/desktop/src/features/launcher/useLauncherController.ts
@@ -729,13 +729,13 @@ export function useLauncherController(): LauncherController {
     inputRef,
     query,
     placeholder: activeArgument
-      ? activeArgument.argument_type === "boolean"
-        ? "true / false"
-        : activeArgument.label
+        ? activeArgument.argument_type === "boolean"
+          ? "true / false"
+          : activeArgument.label
       : interactiveSession
         ? interactiveSession.input_placeholder
         : inputMode === "browser_tabs"
-          ? "Search open windows and tabs"
+          ? "Search open Chrome tabs"
           : "Type a command",
     inputMode,
     onQueryChange,
@@ -781,7 +781,7 @@ function normalizeBrowserTabQuery(query: string): string {
 }
 
 function shouldRestoreFocusAfterSuccess(result: SearchResult): boolean {
-  return result.kind !== "browser_tab" && result.kind !== "open_window";
+  return result.kind !== "browser_tab";
 }
 
 async function resolveLauncherSearch(query: string): Promise<{

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -1,7 +1,7 @@
 use rayon_types::{
     BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandId, CommandInputMode,
-    ImageAssetDefinition, InstalledApp, OpenWindow, OpenWindowTarget, ProcessMatch,
-    SearchIndexStats, SearchResult, SearchResultKind, SearchableItemDocument,
+    ImageAssetDefinition, InstalledApp, ProcessMatch, SearchIndexStats, SearchResult,
+    SearchResultKind, SearchableItemDocument,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -13,8 +13,6 @@ pub trait AppPlatform: Send + Sync {
     fn copy_image_to_clipboard(&self, image_path: &Path) -> Result<(), String>;
     fn search_browser_tabs(&self, query: &str) -> Result<Vec<BrowserTab>, String>;
     fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String>;
-    fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String>;
-    fn focus_open_window(&self, target: &OpenWindowTarget) -> Result<(), String>;
     fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String>;
     fn terminate_process(&self, pid: u32) -> Result<(), String>;
 }

--- a/crates/core/src/launcher/execution.rs
+++ b/crates/core/src/launcher/execution.rs
@@ -36,12 +36,6 @@ impl LauncherService {
                     output: result.output,
                 })
             }
-            ExecutionTarget::OpenWindow(target) => {
-                let result = self.focus_open_window(&target)?;
-                Ok(CommandInvocationResult::Completed {
-                    output: result.output,
-                })
-            }
             ExecutionTarget::Bookmark(bookmark_id) => {
                 let result = self.open_bookmark(&bookmark_id)?;
                 Ok(CommandInvocationResult::Completed {
@@ -138,19 +132,6 @@ impl LauncherService {
 
         Ok(CommandExecutionResult {
             output: "focused Chrome tab".into(),
-        })
-    }
-
-    fn focus_open_window(
-        &self,
-        target: &rayon_types::OpenWindowTarget,
-    ) -> Result<CommandExecutionResult, LauncherError> {
-        self.platform
-            .focus_open_window(target)
-            .map_err(LauncherError::Platform)?;
-
-        Ok(CommandExecutionResult {
-            output: "focused window".into(),
         })
     }
 

--- a/crates/core/src/launcher/routing.rs
+++ b/crates/core/src/launcher/routing.rs
@@ -1,14 +1,10 @@
 use crate::commands::APP_REINDEX_COMMAND_ID;
-use rayon_types::{
-    parse_browser_tab_command_id, parse_open_window_command_id, BrowserTabTarget, CommandId,
-    OpenWindowTarget,
-};
+use rayon_types::{parse_browser_tab_command_id, BrowserTabTarget, CommandId};
 
 pub(super) enum ExecutionTarget {
     Reindex,
     App(CommandId),
     BrowserTab(BrowserTabTarget),
-    OpenWindow(OpenWindowTarget),
     Bookmark(CommandId),
     Image(CommandId),
     Provider(CommandId),
@@ -29,10 +25,6 @@ pub(super) fn resolve_execution_target(
 
     if let Some(target) = parse_browser_tab_command_id(command_id) {
         return ExecutionTarget::BrowserTab(target);
-    }
-
-    if let Some(target) = parse_open_window_command_id(command_id) {
-        return ExecutionTarget::OpenWindow(target);
     }
 
     if bookmark_exists {

--- a/crates/core/src/launcher/tests.rs
+++ b/crates/core/src/launcher/tests.rs
@@ -10,7 +10,7 @@ use rayon_types::{
     CommandId, CommandInputMode, CommandInvocationResult, ImageAssetDefinition,
     InteractiveSessionCompletionBehavior, InteractiveSessionMetadata,
     InteractiveSessionQueryRequest, InteractiveSessionResult, InteractiveSessionSubmitRequest,
-    InteractiveSessionSubmitResult, OpenWindow, OpenWindowTarget, SearchResultKind,
+    InteractiveSessionSubmitResult, SearchResultKind,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -90,8 +90,6 @@ fn aggregate_search_does_not_include_browser_tabs() {
             url: "https://example.com/arc".into(),
         }]),
         focused_browser_tabs: Mutex::new(Vec::new()),
-        open_windows: Mutex::new(Vec::new()),
-        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -184,8 +182,6 @@ fn execute_routes_browser_tab_ids_to_platform_focus() {
             url: "https://github.com/alexandrelam/rayon/issues/15".into(),
         }]),
         focused_browser_tabs: Mutex::new(Vec::new()),
-        open_windows: Mutex::new(Vec::new()),
-        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -213,62 +209,6 @@ fn execute_routes_browser_tab_ids_to_platform_focus() {
             browser: "chrome".into(),
             window_id: "window-1".into(),
             tab_index: 4,
-        }
-    );
-}
-
-#[allow(clippy::unwrap_used)]
-#[test]
-fn execute_routes_open_window_ids_to_platform_focus() {
-    let platform = Arc::new(StubPlatform {
-        apps: Vec::new(),
-        launched: Mutex::new(Vec::new()),
-        opened_urls: Mutex::new(Vec::new()),
-        copied_images: Mutex::new(Vec::new()),
-        browser_tabs: Mutex::new(Vec::new()),
-        focused_browser_tabs: Mutex::new(Vec::new()),
-        open_windows: Mutex::new(vec![OpenWindow {
-            application: "Arc".into(),
-            pid: 4242,
-            window_number: 777,
-            bounds_x: 10,
-            bounds_y: 20,
-            bounds_width: 1440,
-            bounds_height: 900,
-            title: "Rayon".into(),
-            is_frontmost: true,
-        }]),
-        focused_open_windows: Mutex::new(Vec::new()),
-        process_search_results: Mutex::new(Vec::new()),
-        terminated_pids: Mutex::new(Vec::new()),
-    });
-    let launcher = launcher_with_platform(platform.clone(), vec![]);
-
-    let result = launcher
-        .execute_command(&CommandExecutionRequest {
-            command_id: CommandId::from("open-window:4242:777:10:20:1440:900"),
-            argv: Vec::new(),
-            arguments: HashMap::new(),
-        })
-        .unwrap();
-
-    assert_eq!(
-        result,
-        CommandInvocationResult::Completed {
-            output: "focused window".into()
-        }
-    );
-
-    let focused = &platform.focused_open_windows.lock().unwrap()[0];
-    assert_eq!(
-        focused,
-        &OpenWindowTarget {
-            pid: 4242,
-            window_number: Some(777),
-            bounds_x: 10,
-            bounds_y: 20,
-            bounds_width: 1440,
-            bounds_height: 900,
         }
     );
 }
@@ -367,8 +307,6 @@ fn completed_interactive_submit_removes_active_session() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
-        open_windows: Mutex::new(Vec::new()),
-        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -514,8 +452,6 @@ fn completed_interactive_submit_calls_provider_cleanup() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
-        open_windows: Mutex::new(Vec::new()),
-        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -572,8 +508,6 @@ fn startup_reindexes_commands_and_apps() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
-        open_windows: Mutex::new(Vec::new()),
-        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -643,8 +577,6 @@ fn aggregate_search_includes_images() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
-        open_windows: Mutex::new(Vec::new()),
-        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });
@@ -686,8 +618,6 @@ fn execute_routes_image_ids_to_clipboard_copy() {
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
-        open_windows: Mutex::new(Vec::new()),
-        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });

--- a/crates/core/src/test_support.rs
+++ b/crates/core/src/test_support.rs
@@ -8,8 +8,7 @@ use rayon_types::{
     BookmarkDefinition, BrowserTab, BrowserTabTarget, CommandArgumentDefinition,
     CommandArgumentType, CommandDefinition, CommandExecutionRequest, CommandExecutionResult,
     CommandId, CommandInputMode, InstalledApp, InteractiveSessionCompletionBehavior,
-    InteractiveSessionMetadata, InteractiveSessionResult, OpenWindow, OpenWindowTarget,
-    ProcessMatch, SearchableItemDocument,
+    InteractiveSessionMetadata, InteractiveSessionResult, ProcessMatch, SearchableItemDocument,
 };
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -182,8 +181,6 @@ pub(crate) struct StubPlatform {
     pub copied_images: Mutex<Vec<String>>,
     pub browser_tabs: Mutex<Vec<BrowserTab>>,
     pub focused_browser_tabs: Mutex<Vec<BrowserTabTarget>>,
-    pub open_windows: Mutex<Vec<OpenWindow>>,
-    pub focused_open_windows: Mutex<Vec<OpenWindowTarget>>,
     pub process_search_results: Mutex<Vec<ProcessMatch>>,
     pub terminated_pids: Mutex<Vec<u32>>,
 }
@@ -225,18 +222,6 @@ impl AppPlatform for StubPlatform {
 
     fn focus_browser_tab(&self, target: &BrowserTabTarget) -> Result<(), String> {
         self.focused_browser_tabs
-            .lock()
-            .unwrap()
-            .push(target.clone());
-        Ok(())
-    }
-
-    fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
-        Ok(self.open_windows.lock().unwrap().clone())
-    }
-
-    fn focus_open_window(&self, target: &OpenWindowTarget) -> Result<(), String> {
-        self.focused_open_windows
             .lock()
             .unwrap()
             .push(target.clone());
@@ -294,8 +279,6 @@ pub(crate) fn build_launcher_service(search_results: Vec<String>) -> LauncherSer
         copied_images: Mutex::new(Vec::new()),
         browser_tabs: Mutex::new(Vec::new()),
         focused_browser_tabs: Mutex::new(Vec::new()),
-        open_windows: Mutex::new(Vec::new()),
-        focused_open_windows: Mutex::new(Vec::new()),
         process_search_results: Mutex::new(Vec::new()),
         terminated_pids: Mutex::new(Vec::new()),
     });

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -265,7 +265,6 @@ fn search_kind(kind: SearchResultKind) -> &'static str {
         SearchResultKind::Bookmark => "bookmark",
         SearchResultKind::Image => "image",
         SearchResultKind::BrowserTab => "browser_tab",
-        SearchResultKind::OpenWindow => "open_window",
     }
 }
 

--- a/crates/features/src/github.rs
+++ b/crates/features/src/github.rs
@@ -349,14 +349,6 @@ mod tests {
             Ok(())
         }
 
-        fn list_open_windows(&self) -> Result<Vec<rayon_types::OpenWindow>, String> {
-            Ok(Vec::new())
-        }
-
-        fn focus_open_window(&self, _target: &rayon_types::OpenWindowTarget) -> Result<(), String> {
-            Ok(())
-        }
-
         fn search_processes(&self, _query: &str) -> Result<Vec<ProcessMatch>, String> {
             Ok(Vec::new())
         }

--- a/crates/features/src/lib.rs
+++ b/crates/features/src/lib.rs
@@ -31,9 +31,7 @@ pub fn built_in_providers(deps: BuiltInDependencies) -> Vec<Arc<dyn CommandProvi
 mod tests {
     use super::*;
     use rayon_core::CommandRegistry;
-    use rayon_types::{
-        BrowserTab, BrowserTabTarget, CommandId, OpenWindow, OpenWindowTarget, ProcessMatch,
-    };
+    use rayon_types::{BrowserTab, BrowserTabTarget, CommandId, ProcessMatch};
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -61,14 +59,6 @@ mod tests {
         }
 
         fn focus_browser_tab(&self, _target: &BrowserTabTarget) -> Result<(), String> {
-            Ok(())
-        }
-
-        fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
-            Ok(Vec::new())
-        }
-
-        fn focus_open_window(&self, _target: &OpenWindowTarget) -> Result<(), String> {
             Ok(())
         }
 

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -1,12 +1,9 @@
 use plist::Value;
-use rayon_types::{
-    BrowserTab, BrowserTabTarget, CommandId, InstalledApp, OpenWindow, OpenWindowTarget,
-    ProcessMatch,
-};
+use rayon_types::{BrowserTab, BrowserTabTarget, CommandId, InstalledApp, ProcessMatch};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::ffi::{c_char, c_void, CStr, OsStr};
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -17,78 +14,6 @@ const APPLICATIONS_DIR: &str = "/Applications";
 const SYSTEM_APPLICATIONS_DIR: &str = "/System/Applications";
 const APPLE_SCRIPT_FIELD_SEPARATOR: char = '\u{001f}';
 const APPLE_SCRIPT_RECORD_SEPARATOR: char = '\u{001e}';
-const OPEN_WINDOW_MATCH_TOLERANCE: i32 = 2;
-
-#[cfg(target_os = "macos")]
-type CFTypeRef = *const c_void;
-#[cfg(target_os = "macos")]
-type CFArrayRef = *const c_void;
-#[cfg(target_os = "macos")]
-type CFDictionaryRef = *const c_void;
-#[cfg(target_os = "macos")]
-type CFStringRef = *const c_void;
-#[cfg(target_os = "macos")]
-type CFNumberRef = *const c_void;
-
-#[cfg(target_os = "macos")]
-#[repr(C)]
-#[derive(Clone, Copy, Default)]
-struct CGPoint {
-    x: f64,
-    y: f64,
-}
-
-#[cfg(target_os = "macos")]
-#[repr(C)]
-#[derive(Clone, Copy, Default)]
-struct CGSize {
-    width: f64,
-    height: f64,
-}
-
-#[cfg(target_os = "macos")]
-#[repr(C)]
-#[derive(Clone, Copy, Default)]
-struct CGRect {
-    origin: CGPoint,
-    size: CGSize,
-}
-
-#[cfg(target_os = "macos")]
-const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
-#[cfg(target_os = "macos")]
-const K_CF_NUMBER_SINT32_TYPE: i32 = 3;
-#[cfg(target_os = "macos")]
-const K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS: u32 = 1 << 4;
-
-#[cfg(target_os = "macos")]
-#[link(name = "ApplicationServices", kind = "framework")]
-extern "C" {
-    static kCGWindowOwnerPID: CFStringRef;
-    static kCGWindowOwnerName: CFStringRef;
-    static kCGWindowName: CFStringRef;
-    static kCGWindowNumber: CFStringRef;
-    static kCGWindowBounds: CFStringRef;
-    static kCGWindowLayer: CFStringRef;
-
-    fn CGWindowListCopyWindowInfo(option: u32, relative_to_window: u32) -> CFArrayRef;
-    fn CGRectMakeWithDictionaryRepresentation(dict: CFDictionaryRef, rect: *mut CGRect) -> bool;
-    fn CFArrayGetCount(the_array: CFArrayRef) -> isize;
-    fn CFArrayGetValueAtIndex(the_array: CFArrayRef, idx: isize) -> *const c_void;
-    fn CFDictionaryGetValueIfPresent(
-        the_dict: CFDictionaryRef,
-        key: *const c_void,
-        value: *mut *const c_void,
-    ) -> u8;
-    fn CFNumberGetValue(number: CFNumberRef, the_type: i32, value_ptr: *mut c_void) -> u8;
-    fn CFRelease(cf: CFTypeRef);
-    fn CFStringGetCString(
-        the_string: CFStringRef,
-        buffer: *mut c_char,
-        buffer_size: isize,
-        encoding: u32,
-    ) -> u8;
-}
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MacOsAppManager;
@@ -186,68 +111,6 @@ impl MacOsAppManager {
         }
 
         Err(last_error.unwrap_or_else(|| "failed to focus Chrome tab".to_string()))
-    }
-
-    pub fn list_open_windows(&self) -> Result<Vec<OpenWindow>, String> {
-        #[cfg(not(target_os = "macos"))]
-        {
-            Ok(Vec::new())
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            let window_list = unsafe {
-                // Use the full window list so windows from other Spaces are indexed too.
-                CGWindowListCopyWindowInfo(K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS, 0)
-            };
-            if window_list.is_null() {
-                return Err("failed to list open windows".into());
-            }
-
-            let _window_list_guard = CfReleaseGuard(window_list);
-            let mut windows = Vec::new();
-            let mut frontmost_available = true;
-            let count = unsafe { CFArrayGetCount(window_list) };
-            for index in 0..count {
-                let dictionary =
-                    unsafe { CFArrayGetValueAtIndex(window_list, index) as CFDictionaryRef };
-                if dictionary.is_null() {
-                    continue;
-                }
-
-                if let Some(mut window) = parse_open_window(dictionary) {
-                    if frontmost_available {
-                        window.is_frontmost = true;
-                        frontmost_available = false;
-                    }
-                    windows.push(window);
-                }
-            }
-
-            Ok(windows)
-        }
-    }
-
-    pub fn focus_open_window(&self, target: &OpenWindowTarget) -> Result<(), String> {
-        let mut last_error = None;
-        for attempt in 0..4 {
-            let output = Command::new("/usr/bin/osascript")
-                .arg("-e")
-                .arg(focus_open_window_script(target))
-                .output()
-                .map_err(|error| format!("failed to focus window: {error}"))?;
-
-            if output.status.success() {
-                return Ok(());
-            }
-
-            last_error = stderr_or_stdout(&output);
-            if attempt < 3 {
-                thread::sleep(Duration::from_millis(100));
-            }
-        }
-
-        Err(last_error.unwrap_or_else(|| "failed to focus window".to_string()))
     }
 
     pub fn search_processes(&self, query: &str) -> Result<Vec<ProcessMatch>, String> {
@@ -572,190 +435,6 @@ fn browser_tab_match_score(tab: &BrowserTab, query: &str) -> Option<(u8, u8, usi
     }
 
     None
-}
-
-#[cfg(target_os = "macos")]
-struct CfReleaseGuard(CFTypeRef);
-
-#[cfg(target_os = "macos")]
-impl Drop for CfReleaseGuard {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            unsafe {
-                CFRelease(self.0);
-            }
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn parse_open_window(dictionary: CFDictionaryRef) -> Option<OpenWindow> {
-    let layer = cf_dictionary_i32(dictionary, unsafe { kCGWindowLayer })?;
-    if layer != 0 {
-        return None;
-    }
-
-    let pid = cf_dictionary_i32(dictionary, unsafe { kCGWindowOwnerPID })?;
-    if pid <= 0 {
-        return None;
-    }
-
-    let window_number = cf_dictionary_i32(dictionary, unsafe { kCGWindowNumber })?;
-    if window_number <= 0 {
-        return None;
-    }
-
-    let application = cf_dictionary_string(dictionary, unsafe { kCGWindowOwnerName })?;
-    if application.is_empty() || application == "Rayon" {
-        return None;
-    }
-
-    let title = cf_dictionary_string(dictionary, unsafe { kCGWindowName }).unwrap_or_default();
-    if title.trim().is_empty() {
-        return None;
-    }
-
-    let bounds = cf_dictionary_rect(dictionary, unsafe { kCGWindowBounds })?;
-    let bounds_x = bounds.origin.x.round() as i32;
-    let bounds_y = bounds.origin.y.round() as i32;
-    let bounds_width = bounds.size.width.round() as i32;
-    let bounds_height = bounds.size.height.round() as i32;
-    if bounds_width <= 1 || bounds_height <= 1 {
-        return None;
-    }
-
-    Some(OpenWindow {
-        application,
-        pid,
-        window_number,
-        bounds_x,
-        bounds_y,
-        bounds_width,
-        bounds_height,
-        title,
-        is_frontmost: false,
-    })
-}
-
-#[cfg(target_os = "macos")]
-fn cf_dictionary_value(dictionary: CFDictionaryRef, key: CFStringRef) -> Option<*const c_void> {
-    let mut value = std::ptr::null();
-    let found = unsafe { CFDictionaryGetValueIfPresent(dictionary, key, &mut value) };
-    if found == 0 || value.is_null() {
-        None
-    } else {
-        Some(value)
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn cf_dictionary_i32(dictionary: CFDictionaryRef, key: CFStringRef) -> Option<i32> {
-    let value = cf_dictionary_value(dictionary, key)? as CFNumberRef;
-    let mut number = 0_i32;
-    let success = unsafe {
-        CFNumberGetValue(
-            value,
-            K_CF_NUMBER_SINT32_TYPE,
-            (&mut number as *mut i32).cast::<c_void>(),
-        )
-    };
-    if success == 0 {
-        None
-    } else {
-        Some(number)
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn cf_dictionary_string(dictionary: CFDictionaryRef, key: CFStringRef) -> Option<String> {
-    let value = cf_dictionary_value(dictionary, key)? as CFStringRef;
-    cf_string_to_string(value)
-}
-
-#[cfg(target_os = "macos")]
-fn cf_dictionary_rect(dictionary: CFDictionaryRef, key: CFStringRef) -> Option<CGRect> {
-    let value = cf_dictionary_value(dictionary, key)? as CFDictionaryRef;
-    let mut rect = CGRect::default();
-    let success = unsafe { CGRectMakeWithDictionaryRepresentation(value, &mut rect) };
-    if success {
-        Some(rect)
-    } else {
-        None
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn cf_string_to_string(value: CFStringRef) -> Option<String> {
-    if value.is_null() {
-        return None;
-    }
-
-    let mut buffer = vec![0_u8; 4096];
-    let success = unsafe {
-        CFStringGetCString(
-            value,
-            buffer.as_mut_ptr().cast::<c_char>(),
-            buffer.len() as isize,
-            K_CF_STRING_ENCODING_UTF8,
-        )
-    };
-    if success == 0 {
-        return None;
-    }
-
-    unsafe { CStr::from_ptr(buffer.as_ptr().cast::<c_char>()) }
-        .to_str()
-        .ok()
-        .map(str::to_string)
-}
-
-fn focus_open_window_script(target: &OpenWindowTarget) -> String {
-    let pid = target.pid;
-    let window_number = target.window_number.unwrap_or_default();
-    let x = target.bounds_x;
-    let y = target.bounds_y;
-    let width = target.bounds_width;
-    let height = target.bounds_height;
-    let tolerance = OPEN_WINDOW_MATCH_TOLERANCE;
-
-    format!(
-        r#"
-tell application "System Events"
-    if UI elements enabled is false then
-        error "Rayon needs Accessibility access to focus windows across Spaces"
-    end if
-
-    if not (exists first application process whose unix id is {pid}) then
-        error "Window application is no longer running"
-    end if
-
-    set targetProcess to first application process whose unix id is {pid}
-end tell
-
-tell application "System Events"
-    tell first application process whose unix id is {pid}
-        set frontmost to true
-        repeat with w in windows
-            set windowPosition to position of w
-            set windowSize to size of w
-            set titleMatches to false
-            try
-                if value of attribute "AXWindowNumber" of w is {window_number} then
-                    set titleMatches to true
-                end if
-            end try
-            if titleMatches or ((abs((item 1 of windowPosition) - {x}) <= {tolerance}) and (abs((item 2 of windowPosition) - {y}) <= {tolerance}) and (abs((item 1 of windowSize) - {width}) <= {tolerance}) and (abs((item 2 of windowSize) - {height}) <= {tolerance})) then
-                perform action "AXRaise" of w
-                set value of attribute "AXMain" of w to true
-                return "ok"
-            end if
-        end repeat
-    end tell
-end tell
-
-error "Window not found"
-"#
-    )
 }
 
 fn app_path_rank(path: &str) -> usize {
@@ -1137,24 +816,6 @@ mod tests {
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].title, "Second");
         assert_eq!(matches[1].title, "First");
-    }
-
-    #[test]
-    fn open_window_focus_script_activates_app_and_prefers_window_number() {
-        let script = focus_open_window_script(&OpenWindowTarget {
-            pid: 4242,
-            window_number: Some(777),
-            bounds_x: 10,
-            bounds_y: 20,
-            bounds_width: 1440,
-            bounds_height: 900,
-        });
-
-        assert!(script.contains("set frontmost to true"));
-        assert!(script.contains("AXWindowNumber"));
-        assert!(script.contains("is 777"));
-        assert!(!script.contains("tell application targetAppName"));
-        assert!(!script.contains("\n    activate\n"));
     }
 
     #[test]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -257,7 +257,6 @@ pub enum SearchResultKind {
     Bookmark,
     Image,
     BrowserTab,
-    OpenWindow,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -269,8 +268,6 @@ pub struct ImageAssetDefinition {
 }
 
 pub const BROWSER_TAB_COMMAND_PREFIX: &str = "browser-tab";
-pub const OPEN_WINDOW_COMMAND_PREFIX: &str = "open-window";
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserTab {
     pub browser: String,
@@ -336,95 +333,6 @@ pub fn parse_browser_tab_command_id(command_id: &CommandId) -> Option<BrowserTab
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OpenWindow {
-    pub application: String,
-    pub pid: i32,
-    pub window_number: i32,
-    pub bounds_x: i32,
-    pub bounds_y: i32,
-    pub bounds_width: i32,
-    pub bounds_height: i32,
-    pub title: String,
-    pub is_frontmost: bool,
-}
-
-impl OpenWindow {
-    pub fn command_id(&self) -> CommandId {
-        CommandId::from(format!(
-            "{OPEN_WINDOW_COMMAND_PREFIX}:{}:{}:{}:{}:{}:{}",
-            self.pid,
-            self.window_number,
-            self.bounds_x,
-            self.bounds_y,
-            self.bounds_width,
-            self.bounds_height
-        ))
-    }
-
-    pub fn display_title(&self) -> String {
-        if self.title.trim().is_empty() {
-            self.application.clone()
-        } else {
-            self.title.clone()
-        }
-    }
-
-    pub fn subtitle(&self) -> String {
-        if self.title.trim().is_empty() {
-            "Open window".into()
-        } else {
-            self.application.clone()
-        }
-    }
-
-    pub fn search_text(&self) -> String {
-        format!("{} {}", self.application, self.title).to_lowercase()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OpenWindowTarget {
-    pub pid: i32,
-    pub window_number: Option<i32>,
-    pub bounds_x: i32,
-    pub bounds_y: i32,
-    pub bounds_width: i32,
-    pub bounds_height: i32,
-}
-
-pub fn parse_open_window_command_id(command_id: &CommandId) -> Option<OpenWindowTarget> {
-    let mut parts = command_id.as_str().split(':');
-    let prefix = parts.next()?;
-    let pid = parts.next()?.parse::<i32>().ok()?;
-    if prefix != OPEN_WINDOW_COMMAND_PREFIX {
-        return None;
-    }
-
-    let remaining_parts = parts.collect::<Vec<_>>();
-    match remaining_parts.as_slice() {
-        [window_number, bounds_x, bounds_y, bounds_width, bounds_height] => {
-            Some(OpenWindowTarget {
-                pid,
-                window_number: window_number.parse::<i32>().ok(),
-                bounds_x: bounds_x.parse::<i32>().ok()?,
-                bounds_y: bounds_y.parse::<i32>().ok()?,
-                bounds_width: bounds_width.parse::<i32>().ok()?,
-                bounds_height: bounds_height.parse::<i32>().ok()?,
-            })
-        }
-        [bounds_x, bounds_y, bounds_width, bounds_height] => Some(OpenWindowTarget {
-            pid,
-            window_number: None,
-            bounds_x: bounds_x.parse::<i32>().ok()?,
-            bounds_y: bounds_y.parse::<i32>().ok()?,
-            bounds_width: bounds_width.parse::<i32>().ok()?,
-            bounds_height: bounds_height.parse::<i32>().ok()?,
-        }),
-        _ => None,
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstalledApp {
     pub id: CommandId,
     pub title: String,
@@ -480,51 +388,4 @@ pub struct ProcessMatch {
     pub executable_name: String,
     pub command: String,
     pub matched_ports: Vec<u16>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn open_window_command_id_round_trips_with_window_number() {
-        let window = OpenWindow {
-            application: "Linear".into(),
-            pid: 4242,
-            window_number: 777,
-            bounds_x: 10,
-            bounds_y: 20,
-            bounds_width: 1440,
-            bounds_height: 900,
-            title: "Project Board".into(),
-            is_frontmost: true,
-        };
-
-        assert_eq!(
-            parse_open_window_command_id(&window.command_id()),
-            Some(OpenWindowTarget {
-                pid: 4242,
-                window_number: Some(777),
-                bounds_x: 10,
-                bounds_y: 20,
-                bounds_width: 1440,
-                bounds_height: 900,
-            })
-        );
-    }
-
-    #[test]
-    fn open_window_command_id_still_parses_legacy_format() {
-        assert_eq!(
-            parse_open_window_command_id(&CommandId::from("open-window:4242:10:20:1440:900")),
-            Some(OpenWindowTarget {
-                pid: 4242,
-                window_number: None,
-                bounds_x: 10,
-                bounds_y: 20,
-                bounds_width: 1440,
-                bounds_height: 900,
-            })
-        );
-    }
 }


### PR DESCRIPTION
## Summary
- remove the open-window leading-space search feature and its macOS-specific execution path
- restore leading-space mode to browser-tab-only behavior
- drop window-specific UI copy, tests, and documentation

## Verification
- cargo test --workspace --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm --dir apps/desktop test -- --runInBand
- pnpm --dir apps/desktop typecheck
- pnpm --dir apps/desktop lint