### PR TITLE
Add motion-driven transitions to the launcher

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.11.0",
+    "motion": "^12.38.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^3.5.0",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -35,7 +35,7 @@ pub fn run() {
         })
         .on_window_event(|window, event| {
             if window.label() == MAIN_WINDOW_LABEL && matches!(event, WindowEvent::Focused(false)) {
-                let _ = window.hide();
+                let _ = shell::hide_launcher(window.app_handle());
             }
         })
         .invoke_handler(tauri::generate_handler![

--- a/apps/desktop/src-tauri/src/shell.rs
+++ b/apps/desktop/src-tauri/src/shell.rs
@@ -9,10 +9,17 @@ use tauri::{
 };
 
 const LAUNCHER_OPENED_EVENT: &str = "launcher:opened";
+const LAUNCHER_OPEN_ANIMATION_MS: u64 = 110;
+const LAUNCHER_CLOSE_ANIMATION_MS: u64 = 110;
 
 fn previous_frontmost_pid() -> &'static Mutex<Option<i32>> {
     static PREVIOUS_FRONTMOST_PID: OnceLock<Mutex<Option<i32>>> = OnceLock::new();
     PREVIOUS_FRONTMOST_PID.get_or_init(|| Mutex::new(None))
+}
+
+fn launcher_hide_pending() -> &'static Mutex<bool> {
+    static LAUNCHER_HIDE_PENDING: OnceLock<Mutex<bool>> = OnceLock::new();
+    LAUNCHER_HIDE_PENDING.get_or_init(|| Mutex::new(false))
 }
 
 pub fn show_launcher(app: &AppHandle) -> tauri::Result<()> {
@@ -21,39 +28,59 @@ pub fn show_launcher(app: &AppHandle) -> tauri::Result<()> {
         .ok_or_else(|| tauri::Error::AssetNotFound(MAIN_WINDOW_LABEL.into()))?;
 
     store_previous_frontmost_application();
+    set_launcher_hide_pending(false);
 
     #[cfg(target_os = "macos")]
     {
         app.show()?;
+        prepare_launcher_window_for_show(&window)?;
     }
 
     window.unminimize()?;
     window.center()?;
     window.show()?;
+
+    #[cfg(target_os = "macos")]
+    animate_launcher_window_alpha(&window, 1.0, LAUNCHER_OPEN_ANIMATION_MS)?;
+
     window.set_focus()?;
     window.emit(LAUNCHER_OPENED_EVENT, ())?;
     Ok(())
 }
 
 pub fn hide_launcher(app: &AppHandle) -> tauri::Result<()> {
-    hide_launcher_window(app)?;
-    clear_previous_frontmost_application();
-    Ok(())
+    hide_launcher_window(app, false)
 }
 
 pub fn hide_launcher_and_restore_focus(app: &AppHandle) -> tauri::Result<()> {
-    hide_launcher_window(app)?;
-    restore_previous_frontmost_application();
-    Ok(())
+    hide_launcher_window(app, true)
 }
 
-fn hide_launcher_window(app: &AppHandle) -> tauri::Result<()> {
+fn hide_launcher_window(app: &AppHandle, restore_focus: bool) -> tauri::Result<()> {
     let window = app
         .get_webview_window(MAIN_WINDOW_LABEL)
         .ok_or_else(|| tauri::Error::AssetNotFound(MAIN_WINDOW_LABEL.into()))?;
 
-    window.hide()?;
-    Ok(())
+    if !window.is_visible()? {
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        start_launcher_hide_animation(app.clone(), restore_focus)?;
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        window.hide()?;
+        if restore_focus {
+            restore_previous_frontmost_application();
+        } else {
+            clear_previous_frontmost_application();
+        }
+        Ok(())
+    }
 }
 
 pub fn toggle_launcher(app: &AppHandle) -> tauri::Result<()> {
@@ -178,6 +205,113 @@ fn restore_previous_frontmost_application() {
 #[cfg(not(target_os = "macos"))]
 fn restore_previous_frontmost_application() {
     clear_previous_frontmost_application();
+}
+
+fn set_launcher_hide_pending(is_pending: bool) {
+    if let Ok(mut pending) = launcher_hide_pending().lock() {
+        *pending = is_pending;
+    }
+}
+
+fn take_launcher_hide_pending() -> bool {
+    if let Ok(mut pending) = launcher_hide_pending().lock() {
+        let was_pending = *pending;
+        *pending = false;
+        return was_pending;
+    }
+
+    false
+}
+
+#[cfg(target_os = "macos")]
+fn start_launcher_hide_animation(app: AppHandle, restore_focus: bool) -> tauri::Result<()> {
+    let window = app
+        .get_webview_window(MAIN_WINDOW_LABEL)
+        .ok_or_else(|| tauri::Error::AssetNotFound(MAIN_WINDOW_LABEL.into()))?;
+
+    if take_if_hide_is_already_pending() {
+        return Ok(());
+    }
+
+    animate_launcher_window_alpha(&window, 0.0, LAUNCHER_CLOSE_ANIMATION_MS)?;
+
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(
+            LAUNCHER_CLOSE_ANIMATION_MS,
+        ));
+        let app_handle = app.clone();
+        let _ = app.run_on_main_thread(move || {
+            if !take_launcher_hide_pending() {
+                return;
+            }
+
+            if let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) {
+                let _ = window.hide();
+            }
+
+            if restore_focus {
+                restore_previous_frontmost_application();
+            } else {
+                clear_previous_frontmost_application();
+            }
+        });
+    });
+
+    Ok(())
+}
+
+fn take_if_hide_is_already_pending() -> bool {
+    if let Ok(mut pending) = launcher_hide_pending().lock() {
+        if *pending {
+            return true;
+        }
+
+        *pending = true;
+    }
+
+    false
+}
+
+#[cfg(target_os = "macos")]
+fn prepare_launcher_window_for_show(window: &tauri::WebviewWindow) -> tauri::Result<()> {
+    set_launcher_window_alpha(window, 0.0)
+}
+
+#[cfg(target_os = "macos")]
+fn animate_launcher_window_alpha(
+    window: &tauri::WebviewWindow,
+    alpha: f64,
+    duration_ms: u64,
+) -> tauri::Result<()> {
+    use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+
+    let ns_window = window.ns_window()? as *mut Object;
+
+    unsafe {
+        let animation_context_class = class!(NSAnimationContext);
+        let _: () = msg_send![animation_context_class, beginGrouping];
+        let context: *mut Object = msg_send![animation_context_class, currentContext];
+        let duration = duration_ms as f64 / 1000.0;
+        let _: () = msg_send![context, setDuration: duration];
+        let animator: *mut Object = msg_send![ns_window, animator];
+        let _: () = msg_send![animator, setAlphaValue: alpha];
+        let _: () = msg_send![animation_context_class, endGrouping];
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn set_launcher_window_alpha(window: &tauri::WebviewWindow, alpha: f64) -> tauri::Result<()> {
+    use objc::{msg_send, runtime::Object, sel, sel_impl};
+
+    let ns_window = window.ns_window()? as *mut Object;
+
+    unsafe {
+        let _: () = msg_send![ns_window, setAlphaValue: alpha];
+    }
+
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/src/shell.rs
+++ b/apps/desktop/src-tauri/src/shell.rs
@@ -12,14 +12,21 @@ const LAUNCHER_OPENED_EVENT: &str = "launcher:opened";
 const LAUNCHER_OPEN_ANIMATION_MS: u64 = 110;
 const LAUNCHER_CLOSE_ANIMATION_MS: u64 = 110;
 
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum PendingHideAction {
+    None,
+    Hide,
+    HideAndRestoreFocus,
+}
+
 fn previous_frontmost_pid() -> &'static Mutex<Option<i32>> {
     static PREVIOUS_FRONTMOST_PID: OnceLock<Mutex<Option<i32>>> = OnceLock::new();
     PREVIOUS_FRONTMOST_PID.get_or_init(|| Mutex::new(None))
 }
 
-fn launcher_hide_pending() -> &'static Mutex<bool> {
-    static LAUNCHER_HIDE_PENDING: OnceLock<Mutex<bool>> = OnceLock::new();
-    LAUNCHER_HIDE_PENDING.get_or_init(|| Mutex::new(false))
+fn launcher_hide_pending() -> &'static Mutex<PendingHideAction> {
+    static LAUNCHER_HIDE_PENDING: OnceLock<Mutex<PendingHideAction>> = OnceLock::new();
+    LAUNCHER_HIDE_PENDING.get_or_init(|| Mutex::new(PendingHideAction::None))
 }
 
 pub fn show_launcher(app: &AppHandle) -> tauri::Result<()> {
@@ -28,7 +35,7 @@ pub fn show_launcher(app: &AppHandle) -> tauri::Result<()> {
         .ok_or_else(|| tauri::Error::AssetNotFound(MAIN_WINDOW_LABEL.into()))?;
 
     store_previous_frontmost_application();
-    set_launcher_hide_pending(false);
+    set_launcher_hide_pending(PendingHideAction::None);
 
     #[cfg(target_os = "macos")]
     {
@@ -207,20 +214,20 @@ fn restore_previous_frontmost_application() {
     clear_previous_frontmost_application();
 }
 
-fn set_launcher_hide_pending(is_pending: bool) {
+fn set_launcher_hide_pending(pending_action: PendingHideAction) {
     if let Ok(mut pending) = launcher_hide_pending().lock() {
-        *pending = is_pending;
+        *pending = pending_action;
     }
 }
 
-fn take_launcher_hide_pending() -> bool {
+fn take_launcher_hide_pending() -> PendingHideAction {
     if let Ok(mut pending) = launcher_hide_pending().lock() {
-        let was_pending = *pending;
-        *pending = false;
-        return was_pending;
+        let pending_action = *pending;
+        *pending = PendingHideAction::None;
+        return pending_action;
     }
 
-    false
+    PendingHideAction::None
 }
 
 #[cfg(target_os = "macos")]
@@ -229,7 +236,7 @@ fn start_launcher_hide_animation(app: AppHandle, restore_focus: bool) -> tauri::
         .get_webview_window(MAIN_WINDOW_LABEL)
         .ok_or_else(|| tauri::Error::AssetNotFound(MAIN_WINDOW_LABEL.into()))?;
 
-    if take_if_hide_is_already_pending() {
+    if register_pending_hide_action(restore_focus) {
         return Ok(());
     }
 
@@ -241,7 +248,8 @@ fn start_launcher_hide_animation(app: AppHandle, restore_focus: bool) -> tauri::
         ));
         let app_handle = app.clone();
         let _ = app.run_on_main_thread(move || {
-            if !take_launcher_hide_pending() {
+            let pending_action = take_launcher_hide_pending();
+            if pending_action == PendingHideAction::None {
                 return;
             }
 
@@ -249,7 +257,7 @@ fn start_launcher_hide_animation(app: AppHandle, restore_focus: bool) -> tauri::
                 let _ = window.hide();
             }
 
-            if restore_focus {
+            if pending_action == PendingHideAction::HideAndRestoreFocus {
                 restore_previous_frontmost_application();
             } else {
                 clear_previous_frontmost_application();
@@ -260,13 +268,22 @@ fn start_launcher_hide_animation(app: AppHandle, restore_focus: bool) -> tauri::
     Ok(())
 }
 
-fn take_if_hide_is_already_pending() -> bool {
+fn register_pending_hide_action(restore_focus: bool) -> bool {
     if let Ok(mut pending) = launcher_hide_pending().lock() {
-        if *pending {
+        let next_action = if restore_focus {
+            PendingHideAction::HideAndRestoreFocus
+        } else {
+            PendingHideAction::Hide
+        };
+
+        if *pending != PendingHideAction::None {
+            if *pending == PendingHideAction::Hide && restore_focus {
+                *pending = PendingHideAction::HideAndRestoreFocus;
+            }
             return true;
         }
 
-        *pending = true;
+        *pending = next_action;
     }
 
     false

--- a/apps/desktop/src/components/motion-primitives/animated-group.tsx
+++ b/apps/desktop/src/components/motion-primitives/animated-group.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from "react";
+import React from "react";
+import { motion, type Variants } from "motion/react";
+
+type AnimatedItemState = {
+  hidden?: Record<string, string | number>;
+  visible?: Record<string, string | number>;
+};
+
+export type AnimatedGroupPreset = "fade" | "slide" | "scale" | "blur-slide";
+
+export type AnimatedGroupProps = {
+  ariaLabel?: string;
+  children: ReactNode;
+  className?: string;
+  variants?: {
+    container?: Variants;
+    item?: Variants;
+  };
+  preset?: AnimatedGroupPreset;
+};
+
+const defaultContainerVariants: Variants = {
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: 0.045,
+      delayChildren: 0.02,
+    },
+  },
+};
+
+const defaultItemState: Required<AnimatedItemState> = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 },
+};
+
+const presetStates: Record<AnimatedGroupPreset, AnimatedItemState> = {
+  fade: {},
+  slide: {
+    hidden: { y: 10 },
+    visible: { y: 0 },
+  },
+  scale: {
+    hidden: { scale: 0.96 },
+    visible: { scale: 1 },
+  },
+  "blur-slide": {
+    hidden: { opacity: 0, y: 12, filter: "blur(4px)" },
+    visible: { opacity: 1, y: 0, filter: "blur(0px)" },
+  },
+};
+
+function buildItemVariants(state: AnimatedItemState): Variants {
+  return {
+    hidden: { ...defaultItemState.hidden, ...state.hidden },
+    visible: { ...defaultItemState.visible, ...state.visible },
+  };
+}
+
+export function AnimatedGroup({
+  ariaLabel,
+  children,
+  className,
+  variants,
+  preset = "blur-slide",
+}: AnimatedGroupProps) {
+  const containerVariants = variants?.container ?? defaultContainerVariants;
+  const itemVariants = variants?.item ?? buildItemVariants(presetStates[preset]);
+
+  return (
+    <motion.ul
+      aria-label={ariaLabel}
+      initial="hidden"
+      animate="visible"
+      variants={containerVariants}
+      className={className}
+    >
+      {React.Children.map(children, (child, index) => (
+        <motion.li key={index} variants={itemVariants}>
+          {child}
+        </motion.li>
+      ))}
+    </motion.ul>
+  );
+}

--- a/apps/desktop/src/components/motion-primitives/animated-group.tsx
+++ b/apps/desktop/src/components/motion-primitives/animated-group.tsx
@@ -77,7 +77,10 @@ export function AnimatedGroup({
       className={className}
     >
       {React.Children.map(children, (child, index) => (
-        <motion.li key={index} variants={itemVariants}>
+        <motion.li
+          key={React.isValidElement(child) && child.key !== null ? child.key : index}
+          variants={itemVariants}
+        >
           {child}
         </motion.li>
       ))}

--- a/apps/desktop/src/features/launcher/Launcher.tsx
+++ b/apps/desktop/src/features/launcher/Launcher.tsx
@@ -1,4 +1,5 @@
 import { LauncherArgumentPanel } from "./components/LauncherArgumentPanel";
+import { LauncherAnimatedPresence } from "./components/LauncherAnimatedPresence";
 import { LauncherFooter } from "./components/LauncherFooter";
 import { LauncherHeader } from "./components/LauncherHeader";
 import { LauncherResultsList } from "./components/LauncherResultsList";
@@ -22,19 +23,25 @@ export function Launcher() {
         onKeyDown={controller.onKeyDown}
       />
 
-      {controller.argumentPanel ? <LauncherArgumentPanel {...controller.argumentPanel} /> : null}
+      <LauncherAnimatedPresence isVisible={controller.argumentPanel !== null}>
+        {controller.argumentPanel ? <LauncherArgumentPanel {...controller.argumentPanel} /> : null}
+      </LauncherAnimatedPresence>
 
-      {controller.showResults ? (
-        <LauncherResultsList
-          items={controller.resultItems}
-          showInteractiveSkeleton={controller.showInteractiveSkeleton}
-          emptyMessage={controller.emptyMessage}
-          onSelect={controller.onResultSelect}
-          setItemRef={controller.setResultItemRef}
-        />
-      ) : null}
+      <LauncherAnimatedPresence isVisible={controller.showResults}>
+        {controller.showResults ? (
+          <LauncherResultsList
+            items={controller.resultItems}
+            showInteractiveSkeleton={controller.showInteractiveSkeleton}
+            emptyMessage={controller.emptyMessage}
+            onSelect={controller.onResultSelect}
+            setItemRef={controller.setResultItemRef}
+          />
+        ) : null}
+      </LauncherAnimatedPresence>
 
-      {controller.showFooter ? <LauncherFooter {...controller.footer} /> : null}
+      <LauncherAnimatedPresence isVisible={controller.showFooter}>
+        {controller.showFooter ? <LauncherFooter {...controller.footer} /> : null}
+      </LauncherAnimatedPresence>
     </LauncherShell>
   );
 }

--- a/apps/desktop/src/features/launcher/components/LauncherAnimatedPresence.tsx
+++ b/apps/desktop/src/features/launcher/components/LauncherAnimatedPresence.tsx
@@ -1,0 +1,24 @@
+import type { PropsWithChildren } from "react";
+import { AnimatePresence, motion } from "motion/react";
+
+export function LauncherAnimatedPresence({
+  children,
+  isVisible,
+}: PropsWithChildren<{
+  isVisible: boolean;
+}>) {
+  return (
+    <AnimatePresence initial={false}>
+      {isVisible ? (
+        <motion.div
+          initial={{ opacity: 0, y: 8, filter: "blur(6px)" }}
+          animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+          exit={{ opacity: 0, y: -4, filter: "blur(6px)" }}
+          transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+        >
+          {children}
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/apps/desktop/src/features/launcher/components/LauncherResultItem.tsx
+++ b/apps/desktop/src/features/launcher/components/LauncherResultItem.tsx
@@ -6,45 +6,47 @@ import { cn } from "@/lib/utils";
 import type { LauncherResultItemViewModel } from "../types";
 
 export function LauncherResultItem({
+  asListItem = true,
   item,
   onSelect,
   setRef,
 }: {
+  asListItem?: boolean;
   item: LauncherResultItemViewModel;
   onSelect: (itemId: string) => void;
   setRef: (node: HTMLButtonElement | null) => void;
 }) {
-  return (
-    <li>
-      <Button
-        type="button"
-        variant="ghost"
-        ref={setRef}
-        data-selected={item.selected}
-        className={cn(
-          "h-auto min-h-12 min-w-0 w-full whitespace-normal rounded-[14px] border border-[var(--result-border)] bg-[var(--result-bg)] px-[13px] py-[11px] text-left text-[var(--panel-foreground)] transition-[transform,border-color,background-color]",
-          "hover:bg-white/65 active:scale-[0.998]",
-          "data-[selected=true]:-translate-y-px data-[selected=true]:border-[var(--selected-border)] data-[selected=true]:bg-[var(--selected-bg)]",
-        )}
-        onMouseDown={(event) => {
-          event.preventDefault();
-        }}
-        onClick={() => {
-          onSelect(item.id);
-        }}
-      >
-        <span className="flex min-w-0 flex-1 items-start gap-2.5">
-          <span className="grid min-w-0 flex-1 gap-[3px]">
-            <span className="truncate font-semibold">{item.title}</span>
-            <span className="overflow-hidden text-[0.78rem] text-[var(--result-id)] [display:-webkit-box] [overflow-wrap:anywhere] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
-              {item.meta}
-            </span>
+  const content = (
+    <Button
+      type="button"
+      variant="ghost"
+      ref={setRef}
+      data-selected={item.selected}
+      className={cn(
+        "h-auto min-h-12 min-w-0 w-full whitespace-normal rounded-[14px] border border-[var(--result-border)] bg-[var(--result-bg)] px-[13px] py-[11px] text-left text-[var(--panel-foreground)] transition-[transform,border-color,background-color,box-shadow]",
+        "hover:bg-white/65 active:scale-[0.998]",
+        "data-[selected=true]:-translate-y-px data-[selected=true]:border-[var(--selected-border)] data-[selected=true]:bg-[var(--selected-bg)] data-[selected=true]:shadow-[0_14px_30px_-24px_rgba(38,120,205,0.58)]",
+      )}
+      onMouseDown={(event) => {
+        event.preventDefault();
+      }}
+      onClick={() => {
+        onSelect(item.id);
+      }}
+    >
+      <span className="flex min-w-0 flex-1 items-start gap-2.5">
+        <span className="grid min-w-0 flex-1 gap-[3px]">
+          <span className="truncate font-semibold">{item.title}</span>
+          <span className="overflow-hidden text-[0.78rem] text-[var(--result-id)] [display:-webkit-box] [overflow-wrap:anywhere] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
+            {item.meta}
           </span>
-          <Badge className="max-w-[7rem] shrink-0 truncate">{item.kind}</Badge>
         </span>
-      </Button>
-    </li>
+        <Badge className="max-w-[7rem] shrink-0 truncate">{item.kind}</Badge>
+      </span>
+    </Button>
   );
+
+  return asListItem ? <li>{content}</li> : content;
 }
 
 export function LauncherResultSkeleton({ index }: { index: number }) {

--- a/apps/desktop/src/features/launcher/components/LauncherResultsList.tsx
+++ b/apps/desktop/src/features/launcher/components/LauncherResultsList.tsx
@@ -1,3 +1,4 @@
+import { AnimatedGroup } from "@/components/motion-primitives/animated-group";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 import type { LauncherResultItemViewModel } from "../types";
@@ -16,32 +17,44 @@ export function LauncherResultsList({
   setItemRef: (itemId: string, node: HTMLButtonElement | null) => void;
   showInteractiveSkeleton: boolean;
 }) {
+  const hasAnimatedResults = !showInteractiveSkeleton && items.length > 0;
+
   return (
     <ScrollArea className="min-w-0 max-h-[var(--results-max-height)] overflow-x-hidden pr-1">
-      <ul
-        aria-label="Search results"
-        className="m-0 grid min-w-0 list-none gap-2 overflow-x-hidden p-[2px_4px_4px_0]"
-      >
-        {showInteractiveSkeleton
-          ? Array.from({ length: 6 }, (_, index) => (
-              <LauncherResultSkeleton key={`skeleton-${String(index)}`} index={index} />
-            ))
-          : items.map((item) => (
-              <LauncherResultItem
-                key={item.id}
-                item={item}
-                onSelect={onSelect}
-                setRef={(node) => {
-                  setItemRef(item.id, node);
-                }}
-              />
-            ))}
-        {emptyMessage ? (
-          <li className="flex min-h-12 min-w-0 items-center justify-center rounded-[14px] border border-[var(--result-border)] bg-[var(--result-bg)] px-[13px] py-[11px] text-[var(--empty)] [overflow-wrap:anywhere]">
-            {emptyMessage}
-          </li>
-        ) : null}
-      </ul>
+      {hasAnimatedResults ? (
+        <AnimatedGroup
+          ariaLabel="Search results"
+          className="m-0 grid min-w-0 list-none gap-2 overflow-x-hidden p-[2px_4px_4px_0]"
+        >
+          {items.map((item) => (
+            <LauncherResultItem
+              key={item.id}
+              asListItem={false}
+              item={item}
+              onSelect={onSelect}
+              setRef={(node) => {
+                setItemRef(item.id, node);
+              }}
+            />
+          ))}
+        </AnimatedGroup>
+      ) : (
+        <ul
+          aria-label="Search results"
+          className="m-0 grid min-w-0 list-none gap-2 overflow-x-hidden p-[2px_4px_4px_0]"
+        >
+          {showInteractiveSkeleton
+            ? Array.from({ length: 6 }, (_, index) => (
+                <LauncherResultSkeleton key={`skeleton-${String(index)}`} index={index} />
+              ))
+            : null}
+          {emptyMessage ? (
+            <li className="flex min-h-12 min-w-0 items-center justify-center rounded-[14px] border border-[var(--result-border)] bg-[var(--result-bg)] px-[13px] py-[11px] text-[var(--empty)] [overflow-wrap:anywhere]">
+              {emptyMessage}
+            </li>
+          ) : null}
+        </ul>
+      )}
     </ScrollArea>
   );
 }

--- a/apps/desktop/src/features/launcher/useLauncherController.ts
+++ b/apps/desktop/src/features/launcher/useLauncherController.ts
@@ -729,9 +729,9 @@ export function useLauncherController(): LauncherController {
     inputRef,
     query,
     placeholder: activeArgument
-        ? activeArgument.argument_type === "boolean"
-          ? "true / false"
-          : activeArgument.label
+      ? activeArgument.argument_type === "boolean"
+        ? "true / false"
+        : activeArgument.label
       : interactiveSession
         ? interactiveSession.input_placeholder
         : inputMode === "browser_tabs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       lucide-react:
         specifier: ^1.11.0
         version: 1.11.0(react@18.3.1)
+      motion:
+        specifier: ^12.38.0
+        version: 12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1378,6 +1381,20 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1690,6 +1707,26 @@ packages:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+
+  motion@12.38.0:
+    resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1925,6 +1962,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -3245,6 +3285,15 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  framer-motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   fsevents@2.3.3:
     optional: true
 
@@ -3506,6 +3555,20 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.0
 
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
+
+  motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      framer-motion: 12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -3714,6 +3777,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.6.3):
     dependencies:
       typescript: 5.6.3
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add Motion support and a small Motion Primitives-style animated group for launcher result entry
- animate launcher state panels as they appear and disappear without changing controller behavior
- refine selected result styling so active rows feel more intentional without slowing keyboard navigation

## Testing
- pnpm --dir apps/desktop lint
- pnpm --dir apps/desktop typecheck
- pnpm --dir apps/desktop test
- cargo test --workspace
